### PR TITLE
Remove hard-coded c:/temp path from unit tests

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -6,12 +6,11 @@
  * available at https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/master/LICENSE
  */
 
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Fhir.Serialization;
-using System.IO;
 using Hl7.Fhir.Model;
-using System.Diagnostics;
+using Hl7.Fhir.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -89,19 +88,20 @@ namespace Hl7.Fhir.Tests.Serialization
         [TestMethod]
         public void EdgecaseRoundtrip()
         {
+            var tempPath = System.IO.Path.GetTempPath();
             string json = File.ReadAllText(@"TestData\json-edge-cases.json");
 
             var poco = FhirParser.ParseResourceFromJson(json);
             Assert.IsNotNull(poco);
             var xml = FhirSerializer.SerializeResourceToXml(poco);
             Assert.IsNotNull(xml);
-            File.WriteAllText(@"c:\temp\edgecase.xml", xml);
+            File.WriteAllText(System.IO.Path.Combine(tempPath, "edgecase.xml"), xml);
 
             poco = FhirParser.ParseResourceFromXml(xml);
             Assert.IsNotNull(poco);
             var json2 = FhirSerializer.SerializeResourceToJson(poco);
             Assert.IsNotNull(json2);
-            File.WriteAllText(@"c:\temp\edgecase.json", json2);
+            File.WriteAllText(System.IO.Path.Combine(tempPath, "edgecase.json"), json2);
            
             JsonAssert.AreSame(json, json2);
         }

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -88,20 +88,20 @@ namespace Hl7.Fhir.Tests.Serialization
         [TestMethod]
         public void EdgecaseRoundtrip()
         {
-            var tempPath = System.IO.Path.GetTempPath();
+            var tempPath = Path.GetTempPath();
             string json = File.ReadAllText(@"TestData\json-edge-cases.json");
 
             var poco = FhirParser.ParseResourceFromJson(json);
             Assert.IsNotNull(poco);
             var xml = FhirSerializer.SerializeResourceToXml(poco);
             Assert.IsNotNull(xml);
-            File.WriteAllText(System.IO.Path.Combine(tempPath, "edgecase.xml"), xml);
+            File.WriteAllText(Path.Combine(tempPath, "edgecase.xml"), xml);
 
             poco = FhirParser.ParseResourceFromXml(xml);
             Assert.IsNotNull(poco);
             var json2 = FhirSerializer.SerializeResourceToJson(poco);
             Assert.IsNotNull(json2);
-            File.WriteAllText(System.IO.Path.Combine(tempPath, "edgecase.json"), json2);
+            File.WriteAllText(Path.Combine(tempPath, "edgecase.json"), json2);
            
             JsonAssert.AreSame(json, json2);
         }

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -74,9 +74,9 @@ namespace Hl7.Fhir.Specification.Tests
 
             if (!areEqual)
             {
-                var tempPath = System.IO.Path.GetTempPath();
-                File.WriteAllText(System.IO.Path.Combine(tempPath, "snapshotgen-source.xml"), FhirSerializer.SerializeResourceToXml(original));
-                File.WriteAllText(System.IO.Path.Combine(tempPath, "snapshotgen-dest.xml"), FhirSerializer.SerializeResourceToXml(expanded));
+                var tempPath = Path.GetTempPath();
+                File.WriteAllText(Path.Combine(tempPath, "snapshotgen-source.xml"), FhirSerializer.SerializeResourceToXml(original));
+                File.WriteAllText(Path.Combine(tempPath, "snapshotgen-dest.xml"), FhirSerializer.SerializeResourceToXml(expanded));
             }
 
             Assert.IsTrue(areEqual);

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -74,8 +74,9 @@ namespace Hl7.Fhir.Specification.Tests
 
             if (!areEqual)
             {
-                File.WriteAllText("c:\\temp\\snapshotgen-source.xml", FhirSerializer.SerializeResourceToXml(original));
-                File.WriteAllText("c:\\temp\\snapshotgen-dest.xml", FhirSerializer.SerializeResourceToXml(expanded));
+                var tempPath = System.IO.Path.GetTempPath();
+                File.WriteAllText(System.IO.Path.Combine(tempPath, "snapshotgen-source.xml"), FhirSerializer.SerializeResourceToXml(original));
+                File.WriteAllText(System.IO.Path.Combine(tempPath, "snapshotgen-dest.xml"), FhirSerializer.SerializeResourceToXml(expanded));
             }
 
             Assert.IsTrue(areEqual);


### PR DESCRIPTION
Two of the unit tests included hard-coded references to c:/temp. As my machine has its temp directory elsewhere and there is a good .Net API to find the correct location, I have replaced the hard-coded references with code to correctly obtain the temp directory (and also use the Path.Combine API to append the filenames to it).
