### PR TITLE
Correctly declare CLS non-compliance.

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -27,7 +27,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>3016, 3015, 1591</NoWarn>
+    <NoWarn>1591</NoWarn>
     <DocumentationFile>bin\Debug\Net45\Hl7.Fhir.DSTU2.Core.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseNet45|AnyCPU' ">
@@ -37,7 +37,8 @@
     <DefineConstants>TRACE;RELEASE;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>3016, 3015</NoWarn>
+    <NoWarn>
+    </NoWarn>
     <DocumentationFile>bin\Release\Net45\Hl7.Fhir.Core.xml</DocumentationFile>
     <DefineConstants>RELEASE;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
@@ -25,6 +25,6 @@ using System.Runtime.InteropServices;
 [assembly:AssemblyKeyFileAttribute("..\\FhirNetApi.snk")]
 #endif
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 
 [assembly: AssemblyVersion("0.90.6.*")]

--- a/src/Hl7.Fhir.Specification/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Specification/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: ComVisible(false)]
-//[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
See issue #161 . This would cleanly declare that Fhir.Net is not CLS compliant. I.e. the Assembly is marked properly, and this also makes the suppression of the compiler warnings obsolete (the compiler only emits warnings CS3015 and 3016 when the assembly is declared to be CLS compliant).
