### PR TITLE
Fix for pull request #156

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -784,7 +784,7 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod]
-        [TestCategory("FhirClient")]
+        [TestCategory("FhirClient"), Ignore]   // Currently ignoring, as spark.furore.com returns Status 500.
         public void TestReceiveHtmlIsHandled()
         {
             var client = new FhirClient("http://spark.furore.com/");        // an address that returns html
@@ -802,6 +802,28 @@ namespace Hl7.Fhir.Tests.Rest
             catch (Exception)
             {
                 Assert.Fail("Failed to throw FormatException on illegal body");
+            }
+        }
+
+
+        [TestMethod]
+        [TestCategory("FhirClient")]
+        public void TestReceiveStatus500IsHandled()
+        {
+            var client = new FhirClient("http://spark.furore.com/");        // an address that returns Status 500
+
+            try
+            {
+                var pat = client.Read<Patient>("Patient/1");
+                Assert.Fail("Failed to throw an Exception on status 500");
+            }
+            catch (FhirOperationException)
+            {
+                // Expected exception happened
+            }
+            catch (Exception)
+            {
+                Assert.Fail("Failed to throw FhirOperationException on status 500");
             }
         }
 

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -817,9 +817,17 @@ namespace Hl7.Fhir.Tests.Rest
                 var pat = client.Read<Patient>("Patient/1");
                 Assert.Fail("Failed to throw an Exception on status 500");
             }
-            catch (FhirOperationException)
+            catch (FhirOperationException fe)
             {
                 // Expected exception happened
+                if (fe.Status != HttpStatusCode.InternalServerError)
+                    Assert.Fail("Server response of 500 did not result in FhirOperationException with status 500.");
+
+                if (client.LastResult == null)
+                    Assert.Fail("LastResult not set in error case.");
+
+                if (client.LastResult.Status != "500")
+                    Assert.Fail("LastResult.Status is not 500.");
             }
             catch (Exception)
             {


### PR DESCRIPTION
Unfortunately, I had overlooked that due to the rebuilt code, the LastResult was not being properly set anymore.
I have fixed the issue and added a dedicated integration test for status 500 response handling.

P.S.: I am wondering whether the Lastxxx properties in Requester.cs should exist? One could safely share the FhirClient between multiple threads otherwise, but it seems the Lastxxx properties will overwrite each other when FhirClient is invoked from multiple threads. But I guess that's a discussion for another day...
