### PR TITLE
Amendment to PR #162: Reenable VB case ambiguity warnings.

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -27,7 +27,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>3016,1591</NoWarn>
     <DocumentationFile>bin\Debug\Net45\Hl7.Fhir.DSTU2.Core.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseNet45|AnyCPU' ">

--- a/src/Hl7.Fhir.Core/Introspection/ReferencesAttribute.cs
+++ b/src/Hl7.Fhir.Core/Introspection/ReferencesAttribute.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 
 namespace Hl7.Fhir.Introspection
 {
+    [CLSCompliant(false)]
     [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
     public class ReferencesAttribute : Attribute
     {

--- a/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
@@ -25,6 +25,8 @@ using System.Runtime.InteropServices;
 [assembly:AssemblyKeyFileAttribute("..\\FhirNetApi.snk")]
 #endif
 
-[assembly: CLSCompliant(false)]
+// This assembly is not fully CLSCompliant, but this triggers compiler warnings to avoid the issue as described here, when mixing C# and VB
+// https://msdn.microsoft.com/en-us/library/ms235408(v=vs.90).aspx
+[assembly: CLSCompliant(true)]
 
 [assembly: AssemblyVersion("0.90.6.*")]

--- a/src/Hl7.Fhir.Core/Validation/AllowedTypesAttribute.cs
+++ b/src/Hl7.Fhir.Core/Validation/AllowedTypesAttribute.cs
@@ -18,6 +18,7 @@ using System.Reflection;
 
 namespace Hl7.Fhir.Validation
 {
+    [CLSCompliant(false)]
     [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
     public class AllowedTypesAttribute : ValidationAttribute
     {

--- a/src/Hl7.Fhir.Specification/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Specification/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
+[assembly: System.CLSCompliant(true)]
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
Hl7.Fhir.Specification is fully CLSCompliant. I.e. assembly flagged as CLSCompliant true and no need to suppress any warnings.

Hl7.Fhir.Core: Mark the 2 offending classes specifically as non-compliant. Only suppress warning CS3016, as CS3015 no longer occurs. Mark overall assembly as CLSCompliant to receive warnings if VB case ambiguity is accidentally introduced.