### PR TITLE
Some clean-up of Requester non-success status handling

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/HttpUtil.cs
+++ b/src/Hl7.Fhir.Core/Rest/HttpUtil.cs
@@ -164,6 +164,30 @@ namespace Hl7.Fhir.Rest
 
             return Regex.IsMatch(uri, RESTURI_PATTERN);
         }
+
+        public static bool IsInformational(this HttpStatusCode code)
+        {
+            return (int)code >= 100 && (int)code < 200;
+        }
+        public static bool IsSuccessful(this HttpStatusCode code)
+        {
+            return (int)code >= 200 && (int)code < 300;
+        }
+
+        public static bool IsRedirection(this HttpStatusCode code)
+        {
+            return (int)code >= 300 && (int)code < 400;
+        }
+
+        public static bool IsClientError(this HttpStatusCode code)
+        {
+            return (int)code >= 400 && (int)code < 500;
+        }
+
+        public static bool IsServerError(this HttpStatusCode code)
+        {
+            return (int)code >= 500 && (int)code < 600;
+        }
     }
 
 


### PR DESCRIPTION
Changed the way we handle non-success http codes, a bit of refactoring to make the flow of the code cleaner.