### PR TITLE
Use strong-named version of Portable.DataAnnotations.

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Hl7.Fhir.Core.Portable45.Tests.csproj
+++ b/src/Hl7.Fhir.Core.Tests/Hl7.Fhir.Core.Portable45.Tests.csproj
@@ -50,7 +50,7 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Portable.DataAnnotations">
-      <HintPath>..\packages\Portable.DataAnnotations.1.0.0\lib\portable-net45+netcore45+wp8+wpa81\Portable.DataAnnotations.dll</HintPath>
+      <HintPath>..\packages\Portable-Strong.DataAnnotations.1.0.0\lib\portable-net45+netcore45+wp8+wpa81\Portable.DataAnnotations.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />

--- a/src/Hl7.Fhir.Core.Tests/packages.config
+++ b/src/Hl7.Fhir.Core.Tests/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net451" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net451" />
+  <package id="Portable-Strong.DataAnnotations" version="1.0.0" targetFramework="net451" />
 </packages>

--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.Portable45.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.Portable45.csproj
@@ -55,8 +55,8 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Portable.DataAnnotations, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Portable.DataAnnotations.1.0.0\lib\portable-net45+netcore45+wp8+wpa81\Portable.DataAnnotations.dll</HintPath>
+    <Reference Include="Portable.DataAnnotations, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6f21be3d5ccff8cd, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable-Strong.DataAnnotations.1.0.0\lib\portable-net45+netcore45+wp8+wpa81\Portable.DataAnnotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Hl7.Fhir.Core/packages.config
+++ b/src/Hl7.Fhir.Core/packages.config
@@ -5,5 +5,6 @@
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Portable.DataAnnotations" version="1.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Portable-Strong.DataAnnotations" version="1.0.0" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="T4.TemplateFileManager" version="2.2.1" targetFramework="net45" />
 </packages>

--- a/src/Hl7.Fhir.Portable45.sln
+++ b/src/Hl7.Fhir.Portable45.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hl7.Fhir.Core", "Hl7.Fhir.Core\Hl7.Fhir.Core.csproj", "{92CC9186-0A21-4E06-B11F-907584FBFD81}"
 EndProject
@@ -86,7 +86,6 @@ Global
 		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.DebugNet45|Any CPU.ActiveCfg = DebugNet45|Any CPU
 		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.DebugNet45|Any CPU.Build.0 = DebugNet45|Any CPU
 		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.Release|Any CPU.ActiveCfg = ReleaseNet45|Any CPU
-		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.Release|Any CPU.Build.0 = ReleaseNet45|Any CPU
 		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.ReleaseNet45|Any CPU.ActiveCfg = ReleaseNet45|Any CPU
 		{6FED47F1-F7EF-42E8-9FF8-FC1439F04DF2}.ReleaseNet45|Any CPU.Build.0 = ReleaseNet45|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
I wasn't as aware of strong naming yet when I submitted PR #165. I referenced a version of Portable.DataAnnotations which was not strong named.
A strong-named version of Portable.DataAnnotations is now available. This PR switches out references to Portable.DataAnnotations by Portable-Strong.DataAnnotations (also available through NuGet).

