### PR TITLE
Search parameters parsing improvements

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
@@ -207,5 +207,167 @@ namespace Hl7.Fhir.Test.Rest
             CollectionAssert.AreEquivalent(q.Parameters.ToList(), q2.Parameters.ToList());
             CollectionAssert.AreEquivalent(q.Elements.ToList(), q2.Elements.ToList());
         }
+
+        [TestMethod]
+        public void AcceptEmptyGenericParam()
+        {
+            var q = new SearchParams();
+            q.Add("parameter", String.Empty);
+            CollectionAssert.AreEquivalent(
+                new[] { Tuple.Create("parameter", String.Empty) }, 
+                q.Parameters.ToList()
+            );
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnDuplicateOrEmptyQueryParam()
+        {
+            FormatExceptionOnDuplicateOrEmptyParam("_query");
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnDuplicateOrEmptyTextParam()
+        {
+            FormatExceptionOnDuplicateOrEmptyParam("_text");
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnDuplicateOrEmptyContentParam()
+        {
+            FormatExceptionOnDuplicateOrEmptyParam("_content");
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnInvalidCountParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_count", String.Empty));
+            Assert.AreEqual("Invalid _count: '' is not a positive integer", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_count", "0"));
+            Assert.AreEqual("Invalid _count: '0' is not a positive integer", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_count", "-100"));
+            Assert.AreEqual("Invalid _count: '-100' is not a positive integer", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_count", "3.14"));
+            Assert.AreEqual("Invalid _count: '3.14' is not a positive integer", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_count", "12zz"));
+            Assert.AreEqual("Invalid _count: '12zz' is not a positive integer", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnEmptyIncludeParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_include", String.Empty));
+            Assert.AreEqual("Invalid _include value: it cannot be empty", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnEmptyRevIncludeParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_revinclude", String.Empty));
+            Assert.AreEqual("Invalid _revinclude value: it cannot be empty", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnInvalidSortParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_sort:", "x"));
+            Assert.AreEqual("Invalid _sort: '' is not a recognized sort order", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_sort:ascz", "x"));
+            Assert.AreEqual("Invalid _sort: 'ascz' is not a recognized sort order", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_sort", String.Empty));
+            Assert.AreEqual("Invalid _sort value: it cannot be empty", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_sort:asc", String.Empty));
+            Assert.AreEqual("Invalid _sort value: it cannot be empty", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_sort:desc", String.Empty));
+            Assert.AreEqual("Invalid _sort value: it cannot be empty", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnInvalidSummaryParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_summary", "x"));
+            Assert.AreEqual("Invalid _summary: 'x' is not a recognized summary value", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_summary", String.Empty));
+            Assert.AreEqual("Invalid _summary: '' is not a recognized summary value", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnDuplicateOrEmptyFilterParam()
+        {
+            FormatExceptionOnDuplicateOrEmptyParam("_filter");
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnInvalidContainedParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_contained", "x"));
+            Assert.AreEqual("Invalid _contained: 'x' is not a recognized contained value", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_contained", String.Empty));
+            Assert.AreEqual("Invalid _contained: '' is not a recognized contained value", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnInvalidContainedTypeParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_containedType", "x"));
+            Assert.AreEqual("Invalid _containedType: 'x' is not a recognized containedType value", formatException.Message);
+
+            formatException = AssertThrows<FormatException>(() => q.Add("_containedType", String.Empty));
+            Assert.AreEqual("Invalid _containedType: '' is not a recognized containedType value", formatException.Message);
+        }
+
+        [TestMethod]
+        public void FormatExceptionOnEmptyElementsParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_elements", String.Empty));
+            Assert.AreEqual("Invalid _elements value: it cannot be empty", formatException.Message);
+        }
+
+        private void FormatExceptionOnDuplicateOrEmptyParam(string paramName)
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add(paramName, String.Empty));
+            Assert.AreEqual(String.Format("Invalid {0} value: it cannot be empty", paramName), formatException.Message);
+
+            q.Add(paramName, "value1");
+            formatException = AssertThrows<FormatException>(() => q.Add(paramName, "value2"));
+            Assert.AreEqual(String.Format("{0} cannot be specified more than once", paramName), formatException.Message);
+        }
+
+        private TException AssertThrows<TException>(Action action) where TException : Exception
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                var result = exception as TException;
+                if (result == null)
+                {
+                    Assert.Fail("Expected {0}, actual {1}", typeof(TException), exception.GetType());
+                }
+                return result;
+            }
+            Assert.Fail("Should have failed");
+            return null;
+        }
     }
 }

--- a/src/Hl7.Fhir.Core/Rest/SearchParams.cs
+++ b/src/Hl7.Fhir.Core/Rest/SearchParams.cs
@@ -111,56 +111,80 @@ namespace Hl7.Fhir.Rest
         {
             if (name == null) throw Error.ArgumentNull("name");
             if (value == null) throw Error.ArgumentNull("value");
-            if (String.IsNullOrEmpty(value)) throw Error.Argument("value", "value cannot be empty");
 
-            if (name == SEARCH_PARAM_QUERY) Query = value;
-            else if (name == SEARCH_PARAM_TEXT) Text = value;
-            else if (name == SEARCH_PARAM_CONTENT) Content = value;
-            else if (name == SEARCH_PARAM_COUNT) Count = Int32.Parse(value);
-            else if (name == SEARCH_PARAM_INCLUDE) Include.Add(value);
-            else if (name == SEARCH_PARAM_REVINCLUDE) RevInclude.Add(value);
+            if (name == SEARCH_PARAM_QUERY) Query = nonEmptySingleValue(name, Query, value);
+            else if (name == SEARCH_PARAM_TEXT) Text = nonEmptySingleValue(name, Text, value);
+            else if (name == SEARCH_PARAM_CONTENT) Content = nonEmptySingleValue(name, Content, value);
+            else if (name == SEARCH_PARAM_COUNT)
+            {
+                int count;
+                if ( !Int32.TryParse(value, out count) || count <= 0) throw Error.Format("Invalid {0}: '{1}' is not a positive integer", null, name, value);
+                Count = count;
+            }
+            else if (name == SEARCH_PARAM_INCLUDE) addNonEmpty(name, Include, value);
+            else if (name == SEARCH_PARAM_REVINCLUDE) addNonEmpty(name, RevInclude, value);
             else if (name.StartsWith(SEARCH_PARAM_SORT + SEARCH_MODIFIERSEPARATOR))
             {
                 var order = name.Substring(SEARCH_PARAM_SORT.Length + 1).ToLower();
 
-                if (order.StartsWith("asc")) Sort.Add(Tuple.Create(value, SortOrder.Ascending));
-                else if (order.StartsWith("desc")) Sort.Add(Tuple.Create(value, SortOrder.Descending));
-                else throw Error.Format("Cannot parse sort order '{0}'", null, order);
+                if ( "ascending".StartsWith(order) && order.Length >= 3) addNonEmptySort(value, SortOrder.Ascending);
+                else if ( "descending".StartsWith(order) && order.Length >= 4) addNonEmptySort(value, SortOrder.Descending);
+                else throw Error.Format("Invalid {0}: '{1}' is not a recognized sort order", null, SEARCH_PARAM_SORT, order);
             }
             else if (name == SEARCH_PARAM_SORT)
             {
-                Sort.Add(Tuple.Create(value, SortOrder.Ascending));
+                addNonEmptySort(value, SortOrder.Ascending);
             }
             else if (name == SEARCH_PARAM_SUMMARY)
             {
                 SummaryType st = SummaryType.False;
-                if (Enum.TryParse<SummaryType>(value, ignoreCase: true, result: out st))
+                if (Enum.TryParse(value, ignoreCase: true, result: out st))
                     Summary = st;
                 else
-                    throw Error.Format("Cannot parse summary value '{0}'", null, value);
+                    throw Error.Format("Invalid {0}: '{1}' is not a recognized summary value", null, name, value);
             }
-            else if (name == SEARCH_PARAM_FILTER) Filter = value;
+            else if (name == SEARCH_PARAM_FILTER) Filter = nonEmptySingleValue(name, Filter, value);
             else if (name == SEARCH_PARAM_CONTAINED)
             {
                 if (SEARCH_CONTAINED_TRUE.Equals(value)) Contained = ContainedSearch.True;
                 else if (SEARCH_CONTAINED_FALSE.Equals(value)) Contained = ContainedSearch.False;
                 else if (SEARCH_CONTAINED_BOTH.Equals(value)) Contained = ContainedSearch.Both;
-                else throw Error.Format("Cannot parse contained value '{0}'", null, value);
+                else throw Error.Format("Invalid {0}: '{1}' is not a recognized contained value", null, name, value);
             }
             else if (name == SEARCH_PARAM_CONTAINEDTYPE)
             {
                 if (SEARCH_CONTAINED_TYPE_CONTAINED.Equals(value)) ContainedType = ContainedResult.Contained;
                 else if (SEARCH_CONTAINED_TYPE_CONTAINER.Equals(value)) ContainedType = ContainedResult.Container;
-                else throw Error.Format("Cannot parse containedType value '{0}'", null, value);
+                else throw Error.Format("Invalid {0}: '{1}' is not a recognized containedType value", null, name, value);
             }
-            else if (name== SEARCH_PARAM_ELEMENTS)
+            else if (name == SEARCH_PARAM_ELEMENTS)
             {
+                if (String.IsNullOrEmpty(value)) throw Error.Format("Invalid {0} value: it cannot be empty", null, name);
                 Elements.AddRange(value.Split(','));
             }
             else
                 Parameters.Add(Tuple.Create(name, value));
 
             return this;
+        }
+
+        private static string nonEmptySingleValue(string paramName, string currentValue, string newValue)
+        {
+            if (String.IsNullOrEmpty(newValue)) throw Error.Format("Invalid {0} value: it cannot be empty", null, paramName);
+            if (!String.IsNullOrEmpty(currentValue)) throw Error.Format("{0} cannot be specified more than once", null, paramName);
+            return newValue;
+        }
+
+        private static void addNonEmpty(string paramName, IList<string> values, string value)
+        {
+            if (String.IsNullOrEmpty(value)) throw Error.Format("Invalid {0} value: it cannot be empty", null, paramName);
+            values.Add(value);
+        }
+
+        private void addNonEmptySort(string value, SortOrder sortOrder)
+        {
+            if (String.IsNullOrEmpty(value)) throw Error.Format("Invalid {0} value: it cannot be empty", null, SEARCH_PARAM_SORT);
+            Sort.Add(Tuple.Create(value, sortOrder));
         }
 
         /// <summary>


### PR DESCRIPTION
All search parameter parsing errors cause a FormatException. The exception message specifies the name of the parameter that caused the error.

Specifying more than once a search parameter that can have only a single value now cause a parsing error – previously there was no error and all values except the last one were ignored.

Sort orders just starting with ‘asc’ or ‘desc’ – e.g. ‘desczzz’ or ‘ascdesc’ were considered valid, now they cause an error. ‘ascending’ and ‘descending’ and their truncations down to ‘asc’ and ‘desc’ are considered valid.

Empty generic search parameters no longer cause an error, and are added ‘as is’ to the SearchParams.Parameters collection. This allow the caller to ignore them or generate appropriate error messages depending on their meaning.

(Based on conversations at the FHIR Connectathon 2016 in Orlando a FHIR server should not fail when a search URL contains unknown parameters with arbitrary values, and this is impossible without this last change)
Fixes https://github.com/ewoutkramer/fhir-net-api/issues/148