### PR TITLE
Modified SpecificationDirectory to start looking in  …

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Source/FileDirectoryArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/FileDirectoryArtifactSource.cs
@@ -19,6 +19,7 @@ using System.Xml;
 using System.Diagnostics;
 using Newtonsoft.Json;
 using Hl7.Fhir.Rest;
+using System.Reflection;
 
 namespace Hl7.Fhir.Specification.Source
 {
@@ -60,7 +61,7 @@ namespace Hl7.Fhir.Specification.Source
         {
             get
             {
-                var codebase = AppDomain.CurrentDomain.BaseDirectory;
+                var codebase = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
                 if (Directory.Exists(codebase))
                     return codebase;


### PR DESCRIPTION
Modified SpecificationDirectory to start looking in
Assembly.GetExecutingAssembly().Location rather than
AppDomain.CurrentDomain.BaseDirectory

AppDomain.CurrentDomain.BaseDirectory is set to a windows directory when running
visual studio unit tests, which causes validation.zip file to not be found.