### PR TITLE
Develop - snapshot generator - PrepareElement event also provides reference to base structure

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -92,7 +92,11 @@ namespace Hl7.Fhir.Specification.Tests
         // [Ignore] // For debugging purposes
         public void GenerateSingleSnapshot()
         {
-            // _settings.MergeTypeProfiles = false;
+            _settings.MergeTypeProfiles = true;
+            _settings.NormalizeElementBase = true;
+            _settings.ExpandExternalProfiles = true;
+            _settings.MarkChanges = false;
+            _settings.ForceExpandAll = true; // TEST
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/daf-condition");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/xdsdocumentreference");
@@ -101,12 +105,14 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/gao-alternate");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/gao-result");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/gao-procedurerequest");
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-guidanceartifact");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-guidanceartifact");
 
             // [WMR 20160825] Examples by Simone Heckman - custom, free-form canonical url
             // => ResourceIdentity is obsolete!
             // var sd = _testResolver.FindStructureDefinition(@"http://fhir.de/StructureDefinition/kbv/betriebsstaette");
             // var sd = _testResolver.FindStructureDefinition(@"http://fhir.de/StructureDefinition/kbv/istNebenbetriebsstaette");
+
+            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyBasic");
 
             Assert.IsNotNull(sd);
 
@@ -326,7 +332,7 @@ namespace Hl7.Fhir.Specification.Tests
         // [Ignore] // For debugging purposes
         public void GenerateSingleSnapshotNormalizeBase()
         {
-            var sd = _testResolver.FindStructureDefinition(@"http://example.org/StructureDefinition/MyBasic");
+            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyBasic");
             Assert.IsNotNull(sd);
 
             // dumpReferences(sd);
@@ -1281,8 +1287,9 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Resource");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/DomainResource");
 
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Basic");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Questionnaire");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Questionnaire");
 
             Assert.IsNotNull(sd);
 

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -347,7 +347,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        // [Ignore] // For debugging purposes
         public void GenerateDerivedProfileSnapshot()
         {
             // cqif-guidanceartifact profile is derived from cqif-knowledgemodule
@@ -369,7 +368,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        //[Ignore]
         public void GeneratePatientWithExtensionsSnapshot()
         {
             // Example by Chris Grenz
@@ -1087,7 +1085,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
             var baseDef = e.BaseElement;
             elem.AddAnnotation(new BaseDefAnnotation(baseDef));
-            Debug.Write("[SnapshotElementHandler] #{0} '{1}' - Base: #{2} '{3}'".FormatWith(elem.GetHashCode(), elem.Path, baseDef.GetHashCode(), baseDef.Path));
+            Debug.Write("[SnapshotElementHandler] #{0} '{1}' - Base: #{2} '{3}' - Base Structure '{4}'".FormatWith(elem.GetHashCode(), elem.Path, baseDef.GetHashCode(), baseDef.Path, e.BaseStructure.Url));
             Debug.WriteLine(ann != null && ann.BaseElementDefinition != null ? " (old Base: #{0} '{1}')".FormatWith(ann.BaseElementDefinition.GetHashCode(), ann.BaseElementDefinition.Path) : "");
         }
 

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyBasic.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyBasic.structuredefinition.xml
@@ -3,7 +3,7 @@
   <meta>
     <lastUpdated value="2016-08-03T18:00:18.565+02:00" />
   </meta>
-  <url value="http://example.org/StructureDefinition/MyBasic" />
+  <url value="http://example.org/fhir/StructureDefinition/MyBasic" />
   <name value="MyBasic" />
   <status value="draft" />
   <fhirVersion value="1.0.2" />

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -102,7 +102,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // snap.base should already be there, and is not changed by the diff
 
-                if (!diff.Type.IsNullOrEmpty() && !diff.Type.IsExactly(snap.Type)) // !diff.IsExactly(snap))
+                if (!diff.Type.IsNullOrEmpty() && !diff.Type.IsExactly(snap.Type))
                 {
                     snap.Type = new List<ElementDefinition.TypeRefComponent>(diff.Type.DeepCopy());
                     foreach (var element in snap.Type) { OnConstraint(snap); }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotElementBaseGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotElementBaseGenerator.cs
@@ -17,7 +17,8 @@ using System.Diagnostics;
 namespace Hl7.Fhir.Specification.Snapshot
 {
     // Methods to (re-)generate the ElementDefinition.Base components from the associated base profile
-    // Controlled by _settings.NormalizeElementBase
+    // Uses annotations on ElementDefinition.Base to suppress duplicate (re-)generation
+    // Behavior is controlled by _settings.NormalizeElementBase
 
     partial class SnapshotGenerator
     {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -313,32 +313,6 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // => snapshot generator should add this
                 fixExtensionUrl(snap);
             }
-
-            // [WMR 20160909] WRONG! This function is only called on differential element constraints
-            // So all other elements with complex types are NOT expanded...!!!
-            //else if (_settings.ExpandUnconstrainedElements)
-            //{
-            //    var types = snap.Current.Type;
-            //    if (types.Count == 1)
-            //    {
-            //        var primaryType = types[0];
-            //        var typeCode = primaryType.Code;
-            //        if (typeCode.HasValue && ModelInfo.IsDataType(typeCode.Value))
-            //        {
-            //            expandElement(snap);
-            //        }
-            //        // [WMR 20160903] Handle unknown/custom core types
-            //        else if (!typeCode.HasValue && primaryType.CodeElement != null)
-            //        {
-            //            var typeName = primaryType.CodeElement.ObjectValue as string;
-            //            if (!string.IsNullOrEmpty(typeName))
-            //            {
-            //                // Assume DataType; no way to determine...
-            //                expandElement(snap);
-            //            }
-            //        }
-            //    }
-            //}
         }
 
         // Merge a differential ElementDefinition constraint into a snapshot ElementDefinition instance.

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -598,7 +598,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Notify observers
                 for (int i = 0; i < snapshot.Element.Count; i++)
                 {
-                    OnPrepareElement(snapshot.Element[i], baseStructure.Snapshot.Element[i]);
+                    OnPrepareElement(snapshot.Element[i], baseStructure, baseStructure.Snapshot.Element[i]);
                 }
             }
             else
@@ -689,7 +689,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         // [WMR 20160906] Always regenerate! Cannot reuse cloned base components
                         ensureElementBase(elem, baseElem, true);
 
-                        OnPrepareElement(elem, baseElem);
+                        OnPrepareElement(elem, baseStructure, baseElem);
                     }
                 }
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -152,6 +152,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
         // ***** Private Interface *****
 
+        // Merge children of the currently selected element from differential into snapshot
         void merge(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff)
         {
             var snapPos = snap.Bookmark();
@@ -218,6 +219,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
         }
 
+        // Create a new resource element without a base element definition (for core type & resource profiles)
         void createNewElement(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff)
         {
             StructureDefinition typeStructure = getStructureForElementType(diff.Current);
@@ -246,6 +248,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             mergeElement(snap, diff);
         }
 
+        // Recursively merge the currently selected element and (grand)children from differential into snapshot
         void mergeElement(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff)
         {
             // [WMR 20160816] Multiple inheritance - diamond problem
@@ -338,6 +341,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             //}
         }
 
+        // Merge a differential ElementDefinition constraint into a snapshot ElementDefinition instance.
         void mergeElementDefinition(ElementDefinition snap, ElementDefinition diff)
         {
             ElementDefnMerger.Merge(this, snap, diff);
@@ -364,8 +368,15 @@ namespace Hl7.Fhir.Specification.Snapshot
         // Following logic is configurable
         // By default, use strategy (A): ignore custom type profile, merge from base
         // If mergeTypeProfiles is enabled, then first merge custom type profile before merging base
+
+        // Resolve the type profile of the currently selected element and merge into snapshot
         bool mergeTypeProfiles(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff)
         {
+            // Debug.Print("[mergeTypeProfiles] {0} : {1}", diff.Path, diff.Current.Type != null && diff.Current.Type.Count == 1 ? diff.Current.PrimaryTypeCode() : null);
+            // [WMR 20160913] Possible improvements:
+            // Don't recurse on special terminator elements, e.g. url, value, id
+            // Note that all these element definitions are marked with: <representation value="xmlAttr"/>
+
             var primaryDiffType = diff.Current.PrimaryType();
             if (primaryDiffType == null || primaryDiffType.IsReference())
             {
@@ -404,8 +415,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                 primaryDiffTypeProfile = profileRef.CanonicalUrl;
             }
 
-            var baseStructure = _resolver.FindStructureDefinition(primaryDiffTypeProfile);
-            if (verifyStructureDef(baseStructure, primaryDiffTypeProfile, ToNamedNode(diff.Current)))
+            var typeStructure = _resolver.FindStructureDefinition(primaryDiffTypeProfile);
+            if (verifyStructureDef(typeStructure, primaryDiffTypeProfile, ToNamedNode(diff.Current)))
             {
                 // Clone and rebase
                 var rebasePath = diff.Path;
@@ -413,21 +424,21 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     rebasePath = ElementDefinitionNavigator.GetParentPath(rebasePath);
                 }
-                var rebasedBaseSnapshot = (StructureDefinition.SnapshotComponent)baseStructure.Snapshot.DeepCopy();
-                rebasedBaseSnapshot.Rebase(rebasePath);
+                var rebasedTypeSnapshot = (StructureDefinition.SnapshotComponent)typeStructure.Snapshot.DeepCopy();
+                rebasedTypeSnapshot.Rebase(rebasePath);
 
                 // [WMR 20160907] Obsolete; performed by verifyStructureDef
                 // generateElementsBase(rebasedBaseSnapshot.Element, baseStructure.Base);
 
-                var baseNav = new ElementDefinitionNavigator(rebasedBaseSnapshot.Element);
+                var typeNav = new ElementDefinitionNavigator(rebasedTypeSnapshot.Element);
 
                 if (!profileRef.IsComplex)
                 {
-                    baseNav.MoveToFirstChild();
+                    typeNav.MoveToFirstChild();
                 }
                 else
                 {
-                    if (!baseNav.JumpToNameReference(profileRef.ElementName))
+                    if (!typeNav.JumpToNameReference(profileRef.ElementName))
                     {
                         addIssueInvalidProfileNameReference(diff.Current, profileRef.ElementName, primaryDiffTypeProfile);
                         return false;
@@ -438,12 +449,12 @@ namespace Hl7.Fhir.Specification.Snapshot
                 if (diff.HasChildren)
                 {
                     // Recursively merge the full profile, then merge overriding constraints from differential
-                    mergeElement(snap, baseNav);
+                    mergeElement(snap, typeNav);
                 }
                 else
                 {
                     // Only merge the profile root element; no need to expand children
-                    mergeElementDefinition(snap.Current, baseNav.Current);
+                    mergeElementDefinition(snap.Current, typeNav.Current);
                 }
 
                 return true;
@@ -800,16 +811,16 @@ namespace Hl7.Fhir.Specification.Snapshot
                         Element = generate(sd)
                     };
 
-#if FORCE_EXPAND_ALL
-                    // Add in-memory annotation to prevent repeated expansion
-                    setCreatedBySnapshotGenerator(sd.Snapshot);
-#endif
                     if (!sd.HasSnapshot)
                     {
                         addIssueSnapshotGenerationFailed(profileUrl);
                         return false;
                     }
 
+#if FORCE_EXPAND_ALL
+                    // Add in-memory annotation to prevent repeated expansion
+                    setCreatedBySnapshotGenerator(sd.Snapshot);
+#endif
                 }
 
                 if (!sd.HasSnapshot)

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorEvents.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorEvents.cs
@@ -83,13 +83,13 @@ namespace Hl7.Fhir.Specification.Snapshot
         public event SnapshotElementHandler PrepareElement;
 
         /// <summary>Raise the <see cref="PrepareElement"/> event to notify the client when an element definition is being prepared for merging.</summary>
-        internal void OnPrepareElement(ElementDefinition element, ElementDefinition baseElement)
+        internal void OnPrepareElement(ElementDefinition element, StructureDefinition baseStructure, ElementDefinition baseElement)
         {
             if (element == null) { throw new ArgumentNullException("element"); }
             var handler = PrepareElement;
             if (handler != null)
             {
-                var args = new SnapshotElementEventArgs(element, baseElement);
+                var args = new SnapshotElementEventArgs(element, baseStructure, baseElement);
                 handler(this, args);
             }
         }
@@ -142,11 +142,13 @@ namespace Hl7.Fhir.Specification.Snapshot
     {
         private readonly ElementDefinition _element;
         private readonly ElementDefinition _baseElement;
+        private readonly StructureDefinition _baseStructure;
 
-        public SnapshotElementEventArgs(ElementDefinition element, ElementDefinition baseElement) : base()
+        public SnapshotElementEventArgs(ElementDefinition element, StructureDefinition baseStructure, ElementDefinition baseElement) : base()
         {
             _element = element;
             _baseElement = baseElement;
+            _baseStructure = baseStructure;
         }
 
         /// <summary>Returns a reference to an element definition.</summary>
@@ -154,6 +156,9 @@ namespace Hl7.Fhir.Specification.Snapshot
 
         /// <summary>Returns a reference to the associated base element definition.</summary>
         public ElementDefinition BaseElement { get { return _baseElement; } }
+
+        /// <summary>Returns a reference to the associated base structure definition. The snapshot component contains the <see cref="BaseElement"/> instance.</summary>
+        public StructureDefinition BaseStructure { get { return _baseStructure; } }
     }
 
     public delegate void SnapshotElementHandler(object sender, SnapshotElementEventArgs e);

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -15,10 +15,9 @@ namespace Hl7.Fhir.Specification.Snapshot
         public static readonly SnapshotGeneratorSettings Default = new SnapshotGeneratorSettings()
         {
             ExpandExternalProfiles = true,
+            ForceExpandAll = false,
             MarkChanges = false,
-
-            // Following settings concern controversial aspects, behavior is not well defined
-            // Needs discussion/decision from HL7 FHIR community
+            // Following settings are proposed and await approval from HL7 WGM
             MergeTypeProfiles = true,
             NormalizeElementBase = true
         };
@@ -33,6 +32,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             MarkChanges = settings.MarkChanges;
             MergeTypeProfiles = settings.MergeTypeProfiles;
             NormalizeElementBase = settings.NormalizeElementBase;
+            ForceExpandAll = settings.ForceExpandAll;
         }
 
         /// <summary>

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -15,7 +15,6 @@ namespace Hl7.Fhir.Specification.Snapshot
         public static readonly SnapshotGeneratorSettings Default = new SnapshotGeneratorSettings()
         {
             ExpandExternalProfiles = true,
-            //ExpandUnconstrainedElements = false,
             MarkChanges = false,
 
             // Following settings concern controversial aspects, behavior is not well defined
@@ -31,7 +30,6 @@ namespace Hl7.Fhir.Specification.Snapshot
         public SnapshotGeneratorSettings(SnapshotGeneratorSettings settings)
         {
             ExpandExternalProfiles = settings.ExpandExternalProfiles;
-            //ExpandUnconstrainedElements = settings.ExpandUnconstrainedElements;
             MarkChanges = settings.MarkChanges;
             MergeTypeProfiles = settings.MergeTypeProfiles;
             NormalizeElementBase = settings.NormalizeElementBase;
@@ -62,16 +60,6 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// The FHIR API snapshot generator explicitly removes and re-generates these extensions for each profile.
         /// </summary>
         public bool MarkChanges { get; set; }
-
-        // /// <summary>
-        // /// EXPERIMENTAL!
-        // /// Enable this setting to recursively expand all profile elements, regardless of wether differential constraints exist.
-        // /// By default, the snapshot generator only expands elements with matching differential constraints.
-        // /// </summary>
-        // /// <remarks>
-        // /// If you enable this setting, the size of the resulting snapshot component may grow significantly due to the additional redundant information.
-        // /// </remarks>
-        // public bool ExpandUnconstrainedElements { get; set; }
 
         /// <summary>
         /// EXPERIMENTAL!


### PR DESCRIPTION
The SnapshotGenerator.PrepareElement provides a reference to the resolved base element definition.
The event arguments now also include a reference to the containing base structure definition.
