### PR TITLE
Develop - snapshot generator - improve events & change tracking

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -983,6 +983,8 @@ namespace Hl7.Fhir.Tests.Rest
             {
                 // OK
             }
+
         }
     }
+
 }

--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
@@ -88,7 +88,28 @@
     <Compile Include="XsltContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="TestData\snapshot-test\Chris Grenz\codeable-with-systems-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="TestData\snapshot-test\Chris Grenz\DAF-Religion-profile.xml.bak">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Include="TestData\snapshot-test\Chris Grenz\encounter-with-type-profile-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\snapshot-test\Chris Grenz\extension-structuredefinition-explicit-type-name.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\organization-team-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-careprovider-type-reslice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-careprovider-type-slice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-deceasedDatetime-slice-profile.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\snapshot-test\Chris Grenz\patient-do-not-call-profile.xml">
@@ -97,13 +118,52 @@
     <Content Include="TestData\snapshot-test\Chris Grenz\patient-extensions-profile.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-gender-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-id-site-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-identifier-profile-slice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-identifier-slice-extension-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\snapshot-test\Chris Grenz\patient-legal-case-lead-counsel-profile.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\snapshot-test\Chris Grenz\patient-legal-case-profile.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-mdm-id-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-mrn-id-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-name-slice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-only-mrn-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-only-mrn-slice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-research-auth-algorithm-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-research-auth-reslice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\snapshot-test\Chris Grenz\patient-research-authorization-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-telecom-reslice-profile.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\snapshot-test\Chris Grenz\patient-telecom-slice-profile.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\snapshot-test\extensions\extension-11179-de-administrative-status.xml">

--- a/src/Hl7.Fhir.Specification.Tests/JsonNavigatorTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/JsonNavigatorTests.cs
@@ -12,7 +12,6 @@ using System.IO;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
-using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.XPath;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -902,12 +902,13 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/qicore-goal");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-guidanceartifact");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyLocation");
-            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
+            // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension1");
 
-            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Meta");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Money");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-basic-guidance-action");
 
@@ -1185,7 +1186,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Element");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/BackboneElement");
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/integer");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/positiveInt");
@@ -1197,6 +1198,7 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/HumanName");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Quantity");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/SimpleQuantity");
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Money");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Resource");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/DomainResource");
@@ -1447,7 +1449,6 @@ namespace Hl7.Fhir.Specification.Tests
 
                 Debug.WriteLineIf(elem.Base != null && path != elem.Base.Path, "EXPANDED: Path = {0} Base = {1} != {2} => INVALID BASE PATH".FormatWith(elem.Path, elem.Base != null ? elem.Base.Path : null, path));
                 Debug.WriteLineIf(orgElem.Base != null && path != orgElem.Base.Path, "ORIGINAL: Path = {0} Base = {1} != {2} => INVALID BASE PATH".FormatWith(orgElem.Path, orgElem.Base != null ? orgElem.Base.Path : null, path));
-
             }
             else
             {

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -59,11 +59,10 @@ namespace Hl7.Fhir.Specification.Tests
         public void GenerateExtensionSnapshot()
         {
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/string-translation");
-            // TODO
-            // var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-research-authorization");
+            var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-research-authorization");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-legal-case");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/us-core-religion");
-            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/string-translation");
+            // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/string-translation");
 
             Assert.IsNotNull(sd);
 
@@ -319,6 +318,7 @@ namespace Hl7.Fhir.Specification.Tests
             dumpBasePaths(expanded);
         }
 
+
         [TestMethod]
         public void GeneratePatientWithExtensionsSnapshot()
         {
@@ -327,7 +327,9 @@ namespace Hl7.Fhir.Specification.Tests
             // Manually downgraded from FHIR v1.4.0 to v1.0.2
 
             // var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/SD/patient-with-extensions");
-            var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-with-extensions");
+            // var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-with-extensions");
+            var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/SD/patient-with-extensions");
+
             Assert.IsNotNull(sd);
             Assert.IsTrue(sd.HasSnapshot);
 
@@ -965,7 +967,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        
+
         // [WMR 20160816] Test custom annotations containing associated base definitions
         class BaseDefAnnotation
         {
@@ -1198,13 +1200,13 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/HumanName");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Quantity");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/SimpleQuantity");
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Money");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Money");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Resource");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/DomainResource");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Basic");
-            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Questionnaire");
 
             Assert.IsNotNull(sd);

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -54,8 +54,8 @@ namespace Hl7.Fhir.Specification.Tests
         // [WMR 20160718] Generate snapshot for extension definition fails with exception:
         // System.ArgumentException: structure is not a constraint or extension
 
+
         [TestMethod]
-        //[Ignore]
         public void GenerateExtensionSnapshot()
         {
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/string-translation");
@@ -88,8 +88,8 @@ namespace Hl7.Fhir.Specification.Tests
             //Assert.IsTrue(expanded.Snapshot.Element[0].Condition.Contains("ext-1"));
         }
 
+
         [TestMethod]
-        // [Ignore] // For debugging purposes
         public void GenerateSingleSnapshot()
         {
             _settings.MergeTypeProfiles = true;
@@ -142,108 +142,6 @@ namespace Hl7.Fhir.Specification.Tests
             dumpBasePaths(expanded);
         }
 
-        //[TestMethod]
-        //[Ignore] // For debugging purposes
-        //public void GenerateSnapshotExpandUnconstrainedElements()
-        //{
-        //    _settings.ExpandUnconstrainedElements = true; // [WMR 20160909] WRONG! OBSOLETE
-        //
-        //    // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/daf-condition");
-        //    // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/daf-patient");
-        //
-        //    // [WMR 20160818] Verify that full expansion does not hang on recursive named references
-        //    // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/sdc-questionnaire");
-        //    var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
-        //
-        //    Assert.IsNotNull(sd);
-        //
-        //    // dumpReferences(sd);
-        //
-        //    // StructureDefinition expanded;
-        //    // generateSnapshotAndCompare(sd, _testSource, out expanded);
-        //
-        //    var expanded = generateSnapshot(sd, _testResolver);
-        //    var areEqual = sd.IsExactly(expanded);
-        //    Assert.IsFalse(areEqual);
-        //
-        //    var identifierElem = expanded.Snapshot.Element.FirstOrDefault(e => e.Type.Count == 1 && e.Type[0].Code == FHIRDefinedType.Identifier);
-        //    if (identifierElem != null)
-        //    {
-        //        var nav = new ElementDefinitionNavigator(expanded.Snapshot.Element);
-        //        Assert.IsTrue(nav.MoveTo(identifierElem));
-        //        Assert.AreEqual(nav.Current, identifierElem);
-        //        Assert.IsTrue(nav.HasChildren, "FAILED! '{0}' is not expanded!".FormatWith(identifierElem.Path));
-        //        Assert.IsTrue(nav.MoveToFirstChild());
-        //        Assert.AreEqual("use", nav.PathName);
-        //        Assert.IsTrue(nav.MoveToNext());
-        //        Assert.AreEqual("type", nav.PathName);
-        //        // ... CodeableConcept ...
-        //        Assert.IsTrue(nav.MoveToNext());
-        //        Assert.AreEqual("system", nav.PathName);
-        //        Assert.IsTrue(nav.MoveToNext());
-        //        Assert.AreEqual("value", nav.PathName);
-        //        Assert.IsTrue(nav.MoveToNext());
-        //        Assert.AreEqual("period", nav.PathName);
-        //        Assert.IsTrue(nav.MoveToNext());
-        //        Assert.AreEqual("assigner", nav.PathName);
-        //    }
-        //
-        //    dumpBasePaths(expanded);
-        //}
-
-        private IList<ElementDefinition> expandAllComplexElements(IList<ElementDefinition> elements)
-        {
-            IList<ElementDefinition> expanded = elements.DeepCopy().ToList();
-            var nav = new ElementDefinitionNavigator(expanded);
-            // Skip root element
-            if (nav.MoveToFirstChild() && nav.MoveToFirstChild())
-            {
-                if (_generator == null)
-                {
-                    _generator = new SnapshotGenerator(_testResolver, _settings);
-                }
-                expandAllComplexChildElements(ref expanded, ref nav);
-            }
-            return expanded;
-        }
-
-        private void expandAllComplexChildElements(ref IList<ElementDefinition> expanded, ref ElementDefinitionNavigator nav)
-        {
-            do
-            {
-                var elem = nav.Current;
-                if (isExpandableElement(elem))
-                {
-                    expanded = _generator.ExpandElement(expanded, elem);
-                    // Must re-initialize the navigator... bit inefficient
-                    nav = new ElementDefinitionNavigator(expanded);
-                    if (!nav.MoveTo(elem))
-                    {
-                        // Shouldn't happen...?
-                        throw new InvalidOperationException("SnapshotGenerator.ExpandElement returned an invalid result.");
-                    }
-                }
-                if (nav.MoveToFirstChild())
-                {
-                    expandAllComplexChildElements(ref expanded, ref nav);
-                    if (!nav.MoveToParent())
-                    {
-                        // Shouldn't happen...?
-                        throw new InvalidOperationException("expandAllComplexChildElements returned an invalid navigator.");
-                    }
-                }
-            } while (nav.MoveToNext());
-        }
-
-        private bool isExpandableElement(ElementDefinition element)
-        {
-            var typeCode = element.PrimaryTypeCode();
-            return typeCode.HasValue
-                   && element.Type.Count == 1
-                   && ModelInfo.IsDataType(typeCode.Value)
-                   && typeCode.Value != FHIRDefinedType.Extension
-                   && typeCode.Value != FHIRDefinedType.BackboneElement;
-        }
 
         [TestMethod]
         public void TestExpandAllComplexElements()
@@ -300,6 +198,61 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
+        IList<ElementDefinition> expandAllComplexElements(IList<ElementDefinition> elements)
+        {
+            IList<ElementDefinition> expanded = elements.DeepCopy().ToList();
+            var nav = new ElementDefinitionNavigator(expanded);
+            // Skip root element
+            if (nav.MoveToFirstChild() && nav.MoveToFirstChild())
+            {
+                if (_generator == null)
+                {
+                    _generator = new SnapshotGenerator(_testResolver, _settings);
+                }
+                expandAllComplexChildElements(ref expanded, ref nav);
+            }
+            return expanded;
+        }
+
+        void expandAllComplexChildElements(ref IList<ElementDefinition> expanded, ref ElementDefinitionNavigator nav)
+        {
+            do
+            {
+                var elem = nav.Current;
+                if (isExpandableElement(elem))
+                {
+                    expanded = _generator.ExpandElement(expanded, elem);
+                    // Must re-initialize the navigator... bit inefficient
+                    nav = new ElementDefinitionNavigator(expanded);
+                    if (!nav.MoveTo(elem))
+                    {
+                        // Shouldn't happen...?
+                        throw new InvalidOperationException("SnapshotGenerator.ExpandElement returned an invalid result.");
+                    }
+                }
+                if (nav.MoveToFirstChild())
+                {
+                    expandAllComplexChildElements(ref expanded, ref nav);
+                    if (!nav.MoveToParent())
+                    {
+                        // Shouldn't happen...?
+                        throw new InvalidOperationException("expandAllComplexChildElements returned an invalid navigator.");
+                    }
+                }
+            } while (nav.MoveToNext());
+        }
+
+        bool isExpandableElement(ElementDefinition element)
+        {
+            var typeCode = element.PrimaryTypeCode();
+            return typeCode.HasValue
+                   && element.Type.Count == 1
+                   && ModelInfo.IsDataType(typeCode.Value)
+                   && typeCode.Value != FHIRDefinedType.Extension
+                   && typeCode.Value != FHIRDefinedType.BackboneElement;
+        }
+
+
         [TestMethod]
         public void TestSnapshotRecursionChecker()
         {
@@ -329,7 +282,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        // [Ignore] // For debugging purposes
         public void GenerateSingleSnapshotNormalizeBase()
         {
             var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyBasic");
@@ -410,7 +362,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        //[Ignore]
         public void GenerateSnapshotExpandExternalProfile()
         {
             // Profile MyLocation references extension MyLocationExtension
@@ -469,12 +420,12 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(outcome);
             Assert.AreEqual(3, outcome.Issue.Count);
 
-            AssertProfileNotFoundIssue(outcome.Issue[0], Validation.Issue.UNAVAILABLE_NEED_SNAPSHOT, "http://example.org/fhir/StructureDefinition/MyExtensionNoSnapshot");
-            AssertProfileNotFoundIssue(outcome.Issue[1], Validation.Issue.UNAVAILABLE_REFERENCED_PROFILE_UNAVAILABLE, "http://example.org/fhir/StructureDefinition/MyIdentifier");
-            AssertProfileNotFoundIssue(outcome.Issue[2], Validation.Issue.UNAVAILABLE_REFERENCED_PROFILE_UNAVAILABLE, "http://example.org/fhir/StructureDefinition/MyCodeableConcept");
+            assertProfileNotFoundIssue(outcome.Issue[0], Validation.Issue.UNAVAILABLE_NEED_SNAPSHOT, "http://example.org/fhir/StructureDefinition/MyExtensionNoSnapshot");
+            assertProfileNotFoundIssue(outcome.Issue[1], Validation.Issue.UNAVAILABLE_REFERENCED_PROFILE_UNAVAILABLE, "http://example.org/fhir/StructureDefinition/MyIdentifier");
+            assertProfileNotFoundIssue(outcome.Issue[2], Validation.Issue.UNAVAILABLE_REFERENCED_PROFILE_UNAVAILABLE, "http://example.org/fhir/StructureDefinition/MyCodeableConcept");
         }
 
-        private static void AssertProfileNotFoundIssue(OperationOutcome.IssueComponent issue, Validation.Issue expected, string profileUrl)
+        static void assertProfileNotFoundIssue(OperationOutcome.IssueComponent issue, Validation.Issue expected, string profileUrl)
         {
             Assert.IsNotNull(issue);
             Assert.AreEqual(expected.Type, issue.Code);
@@ -518,27 +469,23 @@ namespace Hl7.Fhir.Specification.Tests
             Debug.WriteLine("Expanded {0} profiles in {1} ms = {2} ms per profile on average.".FormatWith(count, duration, avg));
         }
 
+        //private void forDoc()
+        //{
+        //    FhirXmlParser parser = new FhirXmlParser(new ParserSettings { AcceptUnknownMembers = true });
+        //    IFhirReader xmlWithPatientData = null;
+        //    var patient = parser.Parse<Patient>(xmlWithPatientData);
 
+        //    // -----
 
-#if false
-        private void forDoc()
-        {
-            FhirXmlParser parser = new FhirXmlParser(new ParserSettings { AcceptUnknownMembers = true });
-            IFhirReader xmlWithPatientData = null;
-            var patient = parser.Parse<Patient>(xmlWithPatientData);
+        //    ArtifactResolver source = ArtifactResolver.CreateCachedDefault();
+        //    var settings = new SnapshotGeneratorSettings { IgnoreMissingTypeProfiles = true };
+        //    StructureDefinition profile = null;
 
-            // -----
+        //    var generator = new SnapshotGenerator(source, _settings);
+        //    generator.Generate(profile);
+        //}
 
-            ArtifactResolver source = ArtifactResolver.CreateCachedDefault();
-            var settings = new SnapshotGeneratorSettings { IgnoreMissingTypeProfiles = true };
-            StructureDefinition profile = null;
-
-            var generator = new SnapshotGenerator(source, _settings);
-            generator.Generate(profile);
-        }
-#endif
-
-        private StructureDefinition generateSnapshot(StructureDefinition original, IResourceResolver source)
+        StructureDefinition generateSnapshot(StructureDefinition original, IResourceResolver source)
         {
             // var generator = new SnapshotGenerator(source, _settings);
             if (_generator == null)
@@ -554,13 +501,13 @@ namespace Hl7.Fhir.Specification.Tests
             return expanded;
         }
 
-        private bool generateSnapshotAndCompare(StructureDefinition original, IResourceResolver source)
+        bool generateSnapshotAndCompare(StructureDefinition original, IResourceResolver source)
         {
             StructureDefinition expanded;
             return generateSnapshotAndCompare(original, source, out expanded);
         }
 
-        private bool generateSnapshotAndCompare(StructureDefinition original, IResourceResolver source, out StructureDefinition expanded)
+        bool generateSnapshotAndCompare(StructureDefinition original, IResourceResolver source, out StructureDefinition expanded)
         {
             expanded = generateSnapshot(original, source);
 
@@ -582,8 +529,7 @@ namespace Hl7.Fhir.Specification.Tests
             return areEqual;
         }
 
-
-        private IEnumerable<StructureDefinition> findConstraintStrucDefs()
+        IEnumerable<StructureDefinition> findConstraintStrucDefs()
         {
             var testSDs = _source.FindAll<StructureDefinition>();
 
@@ -711,7 +657,7 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandElement(sd, nav.Current);
         }
 
-        private void testExpandElement(string srcProfileUrl, string expandElemPath)
+        void testExpandElement(string srcProfileUrl, string expandElemPath)
         {
             // Prepare...
             var sd = _testResolver.FindStructureDefinition(srcProfileUrl);
@@ -730,7 +676,7 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandElement(sd, elem);
         }
 
-        private void testExpandElement(StructureDefinition sd, ElementDefinition elem)
+        void testExpandElement(StructureDefinition sd, ElementDefinition elem)
         {
             Assert.IsNotNull(elem);
             var elems = sd.Snapshot.Element;
@@ -744,7 +690,7 @@ namespace Hl7.Fhir.Specification.Tests
             verifyExpandElement(elem, elems, result);
         }
 
-        private void verifyExpandElement(ElementDefinition elem, List<ElementDefinition> elems, IList<ElementDefinition> result)
+        void verifyExpandElement(ElementDefinition elem, List<ElementDefinition> elems, IList<ElementDefinition> result)
         {
             var expandElemPath = elem.Path;
 
@@ -834,7 +780,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20160722] For debugging purposes
         [Conditional("DEBUG")]
-        private void dumpReferences(StructureDefinition sd, bool differential = false)
+        void dumpReferences(StructureDefinition sd, bool differential = false)
         {
             if (sd != null)
             {
@@ -846,7 +792,7 @@ namespace Hl7.Fhir.Specification.Tests
                 // if (!Directory.Exists(folderPath)) { Directory.CreateDirectory(folderPath); }
 
                 var component = differential ? sd.Differential.Element : sd.Snapshot.Element;
-                var profiles = EnumerateDistinctTypeProfiles(component);
+                var profiles = enumerateDistinctTypeProfiles(component);
 
                 Debug.Indent();
                 foreach (var profile in profiles)
@@ -869,7 +815,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static IEnumerable<string> EnumerateDistinctTypeProfiles(IList<ElementDefinition> elements)
+        static IEnumerable<string> enumerateDistinctTypeProfiles(IList<ElementDefinition> elements)
         {
             return elements.SelectMany(e => e.Type).SelectMany(t => t.Profile).Distinct();
         }
@@ -942,12 +888,6 @@ namespace Hl7.Fhir.Specification.Tests
             Debug.Print(sb.ToString());
         }
 
-        // [WMR 20160816] Test custom annotations containing associated base definitions
-        class BaseDefAnnotation
-        {
-            public BaseDefAnnotation(ElementDefinition baseElemDef) { BaseElementDefinition = baseElemDef; }
-            public ElementDefinition BaseElementDefinition { get; private set; }
-        }
 
         [TestMethod]
         public void GenerateSnapshotEmitBaseData()
@@ -962,11 +902,15 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/qicore-goal");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-guidanceartifact");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyLocation");
-            // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
+            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
+            // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension1");
 
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Meta");
+
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-basic-guidance-action");
+
 
             Assert.IsNotNull(sd);
             // dumpReferences(sd);
@@ -976,52 +920,8 @@ namespace Hl7.Fhir.Specification.Tests
             settings.MergeTypeProfiles = true;
             settings.MarkChanges = true;
             settings.NormalizeElementBase = true;
-            _settings.ForceExpandAll = true;
+            settings.ForceExpandAll = true;
             _generator = new SnapshotGenerator(source, settings);
-
-            // [WMR 20160817] Attach custom event handlers
-            // Following event is called for each separate (external) profile that is being expanded
-            //SnapshotBaseProfileHandler profileHandler = (sender, args) =>
-            //{
-            //    var profile = args.Profile;
-            //    Assert.IsTrue(sd.Url != profile.Url || sd.IsExactly(profile));
-            //    var baseProfile = args.BaseProfile;
-            //    Assert.IsNotNull(baseProfile);
-            //    Debug.WriteLine("[SnapshotBaseProfileHandler] Profile #{0} '{1}' Base = '{2}'".FormatWith(profile.GetHashCode(), profile.Url, profile.Base));
-            //    Debug.Print("[SnapshotBaseProfileHandler] Base Profile #{0} '{1}'".FormatWith(baseProfile.GetHashCode(), baseProfile.Url));
-            //    var rootElem = baseProfile.Snapshot.Element[0];
-            //    Debug.Print("[SnapshotBaseProfileHandler] Base Root element #{0} '{1}'".FormatWith(rootElem.GetHashCode(), rootElem.Path));
-            //    Assert.AreEqual(profile.Base, baseProfile.Url);
-            //};
-
-            //SnapshotElementHandler elementHandler = (sender, args) =>
-            //{
-            //    var elem = args.Element;
-            //    Assert.IsNotNull(elem);
-            //    var ann = elem.Annotation<BaseDefAnnotation>();
-            //    // We want to annotate a reference to the matching base element from the (immediate) base profile.
-            //    // When the snapshot generator expands external profiles, then this handler is called once for each
-            //    // profile in the base hierarchy, starting at the root profile, e.g. Resource => DomainResource => Patient.
-            //    // Each time we recreate the annotation, so the final annotation contains a reference to the immediate base.
-            //    if (ann != null)
-            //    {
-            //        elem.RemoveAnnotations<BaseDefAnnotation>();
-            //    }
-            //    var baseDef = args.BaseElement;
-            //    elem.AddAnnotation(new BaseDefAnnotation(baseDef));
-            //    Debug.Write("[SnapshotElementHandler] #{0} '{1}' - Base: #{2} '{3}'".FormatWith(elem.GetHashCode(), elem.Path, baseDef.GetHashCode(), baseDef.Path));
-            //    Debug.WriteLine(ann != null && ann.BaseElementDefinition != null ? " (old Base: #{0} '{1}')".FormatWith(ann.BaseElementDefinition.GetHashCode(), ann.BaseElementDefinition.Path) : "");
-            //};
-
-            //SnapshotConstraintHandler constraintHandler = (sender, args) =>
-            //{
-            //    var elem = args.Element as ElementDefinition;
-            //    if (elem != null)
-            //    {
-            //        var changed = elem.GetChangedByDiff() == true;
-            //        Debug.Print("[SnapshotConstraintHandler] #{0} '{1}'{2}".FormatWith(elem.GetHashCode(), elem.Path, changed ? " CHANGED!" : null));
-            //    }
-            //};
 
             try
             {
@@ -1064,7 +964,15 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        private void ProfileHandler(object sender, SnapshotBaseProfileEventArgs e)
+        
+        // [WMR 20160816] Test custom annotations containing associated base definitions
+        class BaseDefAnnotation
+        {
+            public BaseDefAnnotation(ElementDefinition baseElemDef) { BaseElementDefinition = baseElemDef; }
+            public ElementDefinition BaseElementDefinition { get; private set; }
+        }
+
+        void ProfileHandler(object sender, SnapshotBaseProfileEventArgs e)
         {
             var profile = e.Profile;
             // Assert.IsTrue(sd.Url != profile.Url || sd.IsExactly(profile));
@@ -1077,7 +985,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(profile.Base, baseProfile.Url);
         }
 
-        private void ElementHandler(object sender, SnapshotElementEventArgs e)
+        void ElementHandler(object sender, SnapshotElementEventArgs e)
         {
             var elem = e.Element;
             Assert.IsNotNull(elem);
@@ -1091,12 +999,13 @@ namespace Hl7.Fhir.Specification.Tests
                 elem.RemoveAnnotations<BaseDefAnnotation>();
             }
             var baseDef = e.BaseElement;
+            var baseStruct = e.BaseStructure;
             elem.AddAnnotation(new BaseDefAnnotation(baseDef));
-            Debug.Write("[SnapshotElementHandler] #{0} '{1}' - Base: #{2} '{3}' - Base Structure '{4}'".FormatWith(elem.GetHashCode(), elem.Path, baseDef.GetHashCode(), baseDef.Path, e.BaseStructure.Url));
+            Debug.Write("[SnapshotElementHandler] #{0} '{1}' - Base: #{2} '{3}' - Base Structure '{4}'".FormatWith(elem.GetHashCode(), elem.Path, baseDef != null ? baseDef.GetHashCode() : 0, baseDef != null ? baseDef.Path : null, baseStruct != null ? baseStruct.Url : null));
             Debug.WriteLine(ann != null && ann.BaseElementDefinition != null ? " (old Base: #{0} '{1}')".FormatWith(ann.BaseElementDefinition.GetHashCode(), ann.BaseElementDefinition.Path) : "");
         }
 
-        private void ConstraintHandler(object sender, SnapshotConstraintEventArgs e)
+        void ConstraintHandler(object sender, SnapshotConstraintEventArgs e)
         {
             var elem = e.Element as ElementDefinition;
             if (elem != null)
@@ -1106,7 +1015,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        private static void assertBaseDefs(StructureDefinition sd, SnapshotGeneratorSettings settings)
+        static void assertBaseDefs(StructureDefinition sd, SnapshotGeneratorSettings settings)
         {
             Assert.IsNotNull(sd);
             Assert.IsNotNull(sd.Snapshot);
@@ -1117,7 +1026,7 @@ namespace Hl7.Fhir.Specification.Tests
             var isConstraint = sd.ConstrainedType.HasValue;
 
             Debug.Print("\r\nStructureDefinition '{0}' url = '{1}'", sd.Name, sd.Url);
-            Debug.Print("# | Constraint? | Changed? | Element.Path | Element.Base.Path | BaseElement.Path | #Base | Invalid?");
+            Debug.Print("# | Constraints? | Changed? | Element.Path | Element.Base.Path | BaseElement.Path | #Base | Invalid?");
             Debug.Print(new string('=', 100));
             foreach (var elem in elems)
             {
@@ -1129,19 +1038,19 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.AreNotEqual(elem, baseDef);
 
                 var hasChanges = HasChanges(elem);
-                var hasConstraints = false; // baseDef != null || elem.Base != null;
-                if (baseDef != null && elem.Base != null)
+                var hasConstraints = false;
+                if (baseDef != null) // && elem.Base != null)
                 {
                     // If normalizing, then elem.Base.Path refers to the defining profile (e.g. DomainResource),
                     // whereas baseDef refers to the immediate base profile (e.g. Patient)
-                    Debug.Assert(settings.NormalizeElementBase || ElementDefinitionNavigator.IsCandidateBaseElementPath(elem.Base.Path, baseDef.Path));
+                    Debug.Assert(settings.NormalizeElementBase || elem.Base == null || ElementDefinitionNavigator.IsCandidateBaseElementPath(elem.Base.Path, baseDef.Path));
                     hasConstraints = HasConstraints(elem, baseDef);
                 }
                 var isValid = hasChanges == hasConstraints;
                 Debug.WriteLine("{0,10}  |  {1}  |  {2,-12}  |  {3,-50}  |  {4,-40}  |  {5,-40}  |  {6,10}  |  {7}",
                     elem.GetHashCode(),
                     hasConstraints ? "+" : "-",
-                    GetChangeDescription(elem),
+                    getChangeDescription(elem),
                     elem.Path,
                     elem.Base != null ? elem.Base.Path : null,
                     baseDef != null ? baseDef.Path : null,
@@ -1156,7 +1065,7 @@ namespace Hl7.Fhir.Specification.Tests
         // Utility function to compare element and base element
         // Path, Base and CHANGED_BY_DIFF_EXT extension are excluded from comparison
         // Returns true if the element has any other constraints on base
-        private static bool HasConstraints(ElementDefinition elem, ElementDefinition baseElem)
+        static bool HasConstraints(ElementDefinition elem, ElementDefinition baseElem)
         {
             var elemClone = (ElementDefinition)elem.DeepCopy();
             var baseClone = (ElementDefinition)baseElem.DeepCopy();
@@ -1173,95 +1082,95 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Returns true if the specified element or any of its' components contain the CHANGED_BY_DIFF_EXT extension
-        private static bool HasChanges(ElementDefinition elem)
+        static bool HasChanges(ElementDefinition elem)
         {
-            return IsChanged(elem)
-                || HasChanges(elem.AliasElement)
-                || IsChanged(elem.Base)
-                || IsChanged(elem.Binding)
-                || HasChanges(elem.Code)
-                || IsChanged(elem.CommentsElement)
-                || HasChanges(elem.ConditionElement)
-                || HasChanges(elem.Constraint)
-                || IsChanged(elem.DefaultValue)
-                || IsChanged(elem.DefinitionElement)
-                || IsChanged(elem.Example)
-                || HasChanges(elem.Extension)
-                || HasChanges(elem.FhirCommentsElement)
-                || IsChanged(elem.Fixed)
-                || IsChanged(elem.IsModifierElement)
-                || IsChanged(elem.IsSummaryElement)
-                || IsChanged(elem.LabelElement)
-                || HasChanges(elem.Mapping)
-                || IsChanged(elem.MaxElement)
-                || IsChanged(elem.MaxLengthElement)
-                || IsChanged(elem.MaxValue)
-                || IsChanged(elem.MeaningWhenMissingElement)
-                || IsChanged(elem.MinElement)
-                || IsChanged(elem.MinValue)
-                || IsChanged(elem.MustSupportElement)
-                || IsChanged(elem.NameElement)
-                || IsChanged(elem.NameReferenceElement)
-                || IsChanged(elem.PathElement)
-                || IsChanged(elem.Pattern)
-                || HasChanges(elem.RepresentationElement)
-                || IsChanged(elem.RequirementsElement)
-                || IsChanged(elem.ShortElement)
-                || IsChanged(elem.Slicing)
-                || HasChanges(elem.Type);
+            return isChanged(elem)
+                || hasChanges(elem.AliasElement)
+                || isChanged(elem.Base)
+                || isChanged(elem.Binding)
+                || hasChanges(elem.Code)
+                || isChanged(elem.CommentsElement)
+                || hasChanges(elem.ConditionElement)
+                || hasChanges(elem.Constraint)
+                || isChanged(elem.DefaultValue)
+                || isChanged(elem.DefinitionElement)
+                || isChanged(elem.Example)
+                || hasChanges(elem.Extension)
+                || hasChanges(elem.FhirCommentsElement)
+                || isChanged(elem.Fixed)
+                || isChanged(elem.IsModifierElement)
+                || isChanged(elem.IsSummaryElement)
+                || isChanged(elem.LabelElement)
+                || hasChanges(elem.Mapping)
+                || isChanged(elem.MaxElement)
+                || isChanged(elem.MaxLengthElement)
+                || isChanged(elem.MaxValue)
+                || isChanged(elem.MeaningWhenMissingElement)
+                || isChanged(elem.MinElement)
+                || isChanged(elem.MinValue)
+                || isChanged(elem.MustSupportElement)
+                || isChanged(elem.NameElement)
+                || isChanged(elem.NameReferenceElement)
+                || isChanged(elem.PathElement)
+                || isChanged(elem.Pattern)
+                || hasChanges(elem.RepresentationElement)
+                || isChanged(elem.RequirementsElement)
+                || isChanged(elem.ShortElement)
+                || isChanged(elem.Slicing)
+                || hasChanges(elem.Type);
         }
 
-        private static string GetChangeDescription(ElementDefinition element)
+        static string getChangeDescription(ElementDefinition element)
         {
-            if (IsChanged(element)) { return "Element"; }
+            if (isChanged(element.Slicing)) { return "Slicing"; }       // Moved to front
+            if (hasChanges(element.Type)) { return "Type"; }            // Moved to front
+            if (isChanged(element.ShortElement)) { return "Short"; }    // Moved to front
 
-
-            if (IsChanged(element.Slicing)) { return "Slicing"; }       // Moved to front
-            if (HasChanges(element.Type)) { return "Type"; }            // Moved to front
-            if (IsChanged(element.ShortElement)) { return "Short"; }    // Moved to front
-
-            if (HasChanges(element.AliasElement)) { return "Alias"; }
-            if (IsChanged(element.Base)) { return "Base"; }
-            if (IsChanged(element.Binding)) { return "Binding"; }
-            if (HasChanges(element.Code)) { return "Code"; }
-            if (IsChanged(element.CommentsElement)) { return "Comments"; }
-            if (HasChanges(element.ConditionElement)) { return "Condition"; }
-            if (HasChanges(element.Constraint)) { return "Constraint"; }
-            if (IsChanged(element.DefaultValue)) { return "DefaultValue"; }
-            if (IsChanged(element.DefinitionElement)) { return "Definition"; }
-            if (IsChanged(element.Example)) { return "Example"; }
-            if (HasChanges(element.Extension)) { return "Extension"; }
-            if (HasChanges(element.FhirCommentsElement)) { return "FhirComments"; }
-            if (IsChanged(element.Fixed)) { return "Fixed"; }
-            if (IsChanged(element.IsModifierElement)) { return "IsModifier"; }
-            if (IsChanged(element.IsSummaryElement)) { return "IsSummary"; }
-            if (IsChanged(element.LabelElement)) { return "Label"; }
-            if (HasChanges(element.Mapping)) { return "Mapping"; }
-            if (IsChanged(element.MaxElement)) { return "Max"; }
-            if (IsChanged(element.MaxLengthElement)) { return "MaxLength"; }
-            if (IsChanged(element.MaxValue)) { return "MaxValue"; }
-            if (IsChanged(element.MeaningWhenMissingElement)) { return "MeaningWhenMissing"; }
-            if (IsChanged(element.MinElement)) { return "Min"; }
-            if (IsChanged(element.MinValue)) { return "MinValue"; }
-            if (IsChanged(element.MustSupportElement)) { return "MustSupport"; }
-            if (IsChanged(element.NameElement)) { return "Name"; }
-            if (IsChanged(element.NameReferenceElement)) { return "NameReference"; }
-            if (IsChanged(element.PathElement)) { return "Path"; }
-            if (IsChanged(element.Pattern)) { return "Pattern"; }
-            if (HasChanges(element.RepresentationElement)) { return "Representation"; }
-            if (IsChanged(element.RequirementsElement)) { return "Requirements"; }
+            if (hasChanges(element.AliasElement)) { return "Alias"; }
+            if (isChanged(element.Base)) { return "Base"; }
+            if (isChanged(element.Binding)) { return "Binding"; }
+            if (hasChanges(element.Code)) { return "Code"; }
+            if (isChanged(element.CommentsElement)) { return "Comments"; }
+            if (hasChanges(element.ConditionElement)) { return "Condition"; }
+            if (hasChanges(element.Constraint)) { return "Constraint"; }
+            if (isChanged(element.DefaultValue)) { return "DefaultValue"; }
+            if (isChanged(element.DefinitionElement)) { return "Definition"; }
+            if (isChanged(element.Example)) { return "Example"; }
+            if (hasChanges(element.Extension)) { return "Extension"; }
+            if (hasChanges(element.FhirCommentsElement)) { return "FhirComments"; }
+            if (isChanged(element.Fixed)) { return "Fixed"; }
+            if (isChanged(element.IsModifierElement)) { return "IsModifier"; }
+            if (isChanged(element.IsSummaryElement)) { return "IsSummary"; }
+            if (isChanged(element.LabelElement)) { return "Label"; }
+            if (hasChanges(element.Mapping)) { return "Mapping"; }
+            if (isChanged(element.MaxElement)) { return "Max"; }
+            if (isChanged(element.MaxLengthElement)) { return "MaxLength"; }
+            if (isChanged(element.MaxValue)) { return "MaxValue"; }
+            if (isChanged(element.MeaningWhenMissingElement)) { return "MeaningWhenMissing"; }
+            if (isChanged(element.MinElement)) { return "Min"; }
+            if (isChanged(element.MinValue)) { return "MinValue"; }
+            if (isChanged(element.MustSupportElement)) { return "MustSupport"; }
+            if (isChanged(element.NameElement)) { return "Name"; }
+            if (isChanged(element.NameReferenceElement)) { return "NameReference"; }
+            if (isChanged(element.PathElement)) { return "Path"; }
+            if (isChanged(element.Pattern)) { return "Pattern"; }
+            if (hasChanges(element.RepresentationElement)) { return "Representation"; }
+            if (isChanged(element.RequirementsElement)) { return "Requirements"; }
             //if (IsChanged(element.ShortElement)) { return "Short"; }
             //if (IsChanged(element.Slicing)) { return "Slicing"; }
             //if (HasChanges(element.Type)) { return "Type"; }
+
+            if (isChanged(element)) { return "Element"; }           // Moved to back
+
             return string.Empty;
         }
 
-        private static bool HasChanges<T>(IList<T> extendables) where T : IExtendable
+        static bool hasChanges<T>(IList<T> extendables) where T : IExtendable
         {
-            return extendables != null ? extendables.Any(e => IsChanged(e)) : false;
+            return extendables != null ? extendables.Any(e => isChanged(e)) : false;
         }
 
-        private static bool IsChanged(IExtendable extendable)
+        static bool isChanged(IExtendable extendable)
         {
             return extendable != null && extendable.GetChangedByDiff() == true;
         }
@@ -1320,7 +1229,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(result);
         }
 
-        IEnumerable<T> EnumerateBundleStream<T>(Stream stream) where T : Resource
+        IEnumerable<T> enumerateBundleStream<T>(Stream stream) where T : Resource
         {
             using (var reader = XmlReader.Create(stream))
             {
@@ -1365,7 +1274,7 @@ namespace Hl7.Fhir.Specification.Tests
                     // var coreDefs = EnumerateBundleStream<StructureDefinition>(stream).ToList();
                     // expandCoreProfilesDerivedFrom(coreDefs, null);
 
-                    var coreDefs = EnumerateBundleStream<StructureDefinition>(stream);
+                    var coreDefs = enumerateBundleStream<StructureDefinition>(stream);
                     coreProfileInfo = coreDefs.Select(sd => new ProfileInfo() { Url = sd.Url, Base = sd.Base }).ToArray();
                 }
                 expandStructuresBasedOn(resolver, coreProfileInfo, null);

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -952,6 +952,8 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void GenerateSnapshotEmitBaseData()
         {
+            var source = _testResolver;
+
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/daf-condition");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.com/fhir/StructureDefinition/patient-with-extensions");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/sdc-questionnaire");
@@ -960,10 +962,12 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/qicore-goal");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-guidanceartifact");
             // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyLocation");
+            // var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
 
-            var source = _testResolver;
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Meta");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/cqif-basic-guidance-action");
 
-            var sd = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyPatient");
             Assert.IsNotNull(sd);
             // dumpReferences(sd);
 
@@ -1032,20 +1036,23 @@ namespace Hl7.Fhir.Specification.Tests
 
                 assertBaseDefs(expanded, settings);
 
-                var sdBase = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
-                assertBaseDefs(sdBase, settings);
+                if (sd.Url == @"http://example.org/fhir/StructureDefinition/MyPatient")
+                {
+                    var sdBase = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
+                    assertBaseDefs(sdBase, settings);
 
-                var sdElem = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Element");
-                assertBaseDefs(sdElem, settings);
+                    var sdElem = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Element");
+                    assertBaseDefs(sdElem, settings);
 
-                var sdExt = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
-                assertBaseDefs(sdExt, settings);
+                    var sdExt = source.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
+                    assertBaseDefs(sdExt, settings);
 
-                var sdExt1 = source.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension1");
-                assertBaseDefs(sdExt1, settings);
+                    var sdExt1 = source.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension1");
+                    assertBaseDefs(sdExt1, settings);
 
-                var sdExt2 = source.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension2");
-                assertBaseDefs(sdExt2, settings);
+                    var sdExt2 = source.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MyExtension2");
+                    assertBaseDefs(sdExt2, settings);
+                }
 
             }
             finally
@@ -1159,8 +1166,8 @@ namespace Hl7.Fhir.Specification.Tests
             baseClone.Base = elem.Base;
 
             // Also ignore any Changed extensions on base and diff
-            elemClone.ClearAllChangedByDiff();
-            baseClone.ClearAllChangedByDiff();
+            elemClone.RemoveAllChangedByDiff();
+            baseClone.RemoveAllChangedByDiff();
 
             return !baseClone.IsExactly(elemClone);
         }
@@ -1269,7 +1276,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Element");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/BackboneElement");
-            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Extension");
 
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/integer");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/positiveInt");
@@ -1285,7 +1292,7 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Resource");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/DomainResource");
 
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Basic");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Basic");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Patient");
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Questionnaire");
 

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/DAF-Religion-profile.xml.bak
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/DAF-Religion-profile.xml.bak
@@ -1,0 +1,106 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+	<name value="DAF-Religion" />
+	<display value="US Core Religion Extension" />
+	<status value="draft" />
+	<publisher value="Health Level Seven International (US Realm Steering Committee)" />
+	<date value="2013-12-03" />
+	<description value="A code classifying a person&#39;s professed religion." />
+	<fhirVersion value="1.4.0" />
+	<kind value="datatype" />
+	<abstract value="false" />
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+	<derivation value="constraint" />
+	<snapshot>
+		<element>
+			<path value="Element" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="1" />
+			<type>
+				<code value="Extension" />
+			</type>
+		</element>
+		<element>
+			<path value="Element.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<min value="0" />
+			<max value="1" />
+			<type>
+				<code value="id" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Element.extension" />
+			<min value="0" />
+			<max value="0" />
+			<type>
+				<code value="Extension" />
+			</type>
+		</element>
+		<element>
+			<path value="Element.url" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+		</element>
+		<element>
+			<path value="Element.value[x]" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Element" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="1" />
+			<type>
+				<code value="Extension" />
+			</type>
+		</element>
+		<element>
+			<path value="Element.extension" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Element.url" />
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+		</element>
+		<element>
+			<path value="Element.value[x]" />
+			<min value="1" />
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/codeable-with-systems-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/codeable-with-systems-profile.xml
@@ -1,0 +1,1199 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/codeable-with-systems" />
+	<name value="codeable-with-systems" />
+	<status value="draft" />
+	<description value="An example of a type profile with named slices." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="orim" />
+		<uri value="http://hl7.org/orim" />
+		<name value="Ontological RIM Mapping" />
+	</mapping>
+	<kind value="datatype" />
+	<constrainedType value="CodeableConcept" />
+	<abstract value="false" />
+	<base value="http://hl7.org/fhir/StructureDefinition/CodeableConcept" />
+	<snapshot>
+		<element>
+			<path value="CodeableConcept" />
+			<short value="Concept - reference to a terminology or just  text" />
+			<definition value="A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding" />
+			<name value="LOINC" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="LOINC.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.extension" />
+			<name value="LOINC.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.system" />
+			<name value="LOINC.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://loinc.org" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.version" />
+			<name value="LOINC.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.code" />
+			<name value="LOINC.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.display" />
+			<name value="LOINC.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.userSelected" />
+			<name value="LOINC.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding" />
+			<name value="SNOMED" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="SNOMED.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.extension" />
+			<name value="SNOMED.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.system" />
+			<name value="SNOMED.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://snomed.info/sct" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.version" />
+			<name value="SNOMED.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.code" />
+			<name value="SNOMED.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.display" />
+			<name value="SNOMED.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.userSelected" />
+			<name value="SNOMED.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="CodeableConcept.text" />
+			<short value="Plain text representation of the concept" />
+			<definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user." />
+			<comments value="Very often the text is the same as a displayName of one of the codings." />
+			<requirements value="The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="CodeableConcept.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.9. But note many systems use C*E.2 for this" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./originalText[mediaType/code=&quot;text/plain&quot;]/data" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="CodeableConcept.coding" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.system" />
+			<name value="LOINC.system" />
+			<min value="1" />
+			<fixedUri value="http://loinc.org" />
+		</element>
+		<element>
+			<path value="CodeableConcept.coding.system" />
+			<name value="SNOMED.system" />
+			<min value="1" />
+			<fixedUri value="http://snomed.info/sct" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/encounter-with-type-profile-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/encounter-with-type-profile-profile.xml
@@ -1,0 +1,4780 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/encounter-with-type-profile" />
+	<name value="encounter-with-type-profile" />
+	<status value="draft" />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Encounter" />
+	<abstract value="false" />
+	<base value="http://hl7.org/fhir/StructureDefinition/Encounter" />
+	<snapshot>
+		<element>
+			<path value="Encounter" />
+			<short value="An interaction during which services are provided to the patient" />
+			<definition value="An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Encounter[moodCode=EVN]" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="workflow.encounter" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.identifier" />
+			<short value="Identifier(s) by which this encounter is known" />
+			<definition value="Identifier(s) by which this encounter is known." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-19" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.status" />
+			<short value="planned | arrived | in-progress | onleave | finished | cancelled" />
+			<definition value="planned | arrived | in-progress | onleave | finished | cancelled." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.status" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Current state of the encounter" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-state" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="No clear equivalent in HL7 v2; active/finished could be inferred from PV1-44, PV1-45, PV2-24; inactive could be inferred from PV2-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory" />
+			<short value="List of past encounter statuses" />
+			<definition value="The status history permits the encounter resource to contain the status history without needing to read through the historical versions of the resource, or even have the server store them." />
+			<comments value="The current status is always found in the current version of the resource, not the status history." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.statusHistory" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory.status" />
+			<short value="planned | arrived | in-progress | onleave | finished | cancelled" />
+			<definition value="planned | arrived | in-progress | onleave | finished | cancelled." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.statusHistory.status" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="Current state of the encounter" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-state" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.statusHistory.period" />
+			<short value="The time that the episode was in the specified status" />
+			<definition value="The time that the episode was in the specified status." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.statusHistory.period" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.class" />
+			<short value="inpatient | outpatient | ambulatory | emergency +" />
+			<definition value="inpatient | outpatient | ambulatory | emergency +." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.class" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Classification of the encounter" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-class" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".inboundRelationship[typeCode=SUBJ].source[classCode=LIST].code" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="class" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type" />
+			<short value="Specific type of encounter" />
+			<definition value="Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation)." />
+			<comments value="Since there are many ways to further classify encounters, this element is 0..*." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.type" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+				<profile value="http://example.com/fhir/SD/codeable-with-systems" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The type of encounter" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-4 / PV1-18" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".code" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="class" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding" />
+			<name value="LOINC" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="LOINC.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.extension" />
+			<name value="LOINC.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.system" />
+			<name value="LOINC.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://loinc.org" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.version" />
+			<name value="LOINC.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.code" />
+			<name value="LOINC.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.display" />
+			<name value="LOINC.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.userSelected" />
+			<name value="LOINC.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding" />
+			<name value="SNOMED" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="SNOMED.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.extension" />
+			<name value="SNOMED.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.system" />
+			<name value="SNOMED.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://snomed.info/sct" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.version" />
+			<name value="SNOMED.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.code" />
+			<name value="SNOMED.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.display" />
+			<name value="SNOMED.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.coding.userSelected" />
+			<name value="SNOMED.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.type.text" />
+			<short value="Plain text representation of the concept" />
+			<definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user." />
+			<comments value="Very often the text is the same as a displayName of one of the codings." />
+			<requirements value="The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="CodeableConcept.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.9. But note many systems use C*E.2 for this" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./originalText[mediaType/code=&quot;text/plain&quot;]/data" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority" />
+			<short value="Indicates the urgency of the encounter" />
+			<definition value="Indicates the urgency of the encounter." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.priority" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+				<profile value="http://example.com/fhir/SD/codeable-with-systems" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="Indicates the urgency of the encounter." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-priority" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV2-25" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".priorityCode" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="grade" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding" />
+			<name value="LOINC" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="LOINC.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.extension" />
+			<name value="LOINC.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.system" />
+			<name value="LOINC.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://loinc.org" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.version" />
+			<name value="LOINC.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.code" />
+			<name value="LOINC.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.display" />
+			<name value="LOINC.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.userSelected" />
+			<name value="LOINC.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding" />
+			<name value="SNOMED" />
+			<short value="Code defined by a terminology system" />
+			<definition value="A reference to a code defined by a terminology system." />
+			<comments value="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labelled as UserSelected = true." />
+			<requirements value="Allows for translations and alternate encodings within a code system.  Also supports communication of the same instance to systems requiring different encodings." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="CodeableConcept.coding" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Coding" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1-8, C*E.10-22" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="union(., ./translation)" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE subset one of the sets of component 1-3 or 4-6" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding rdfs:subClassOf dt:CDCoding" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.id" />
+			<representation value="xmlAttr" />
+			<name value="SNOMED.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.extension" />
+			<name value="SNOMED.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.system" />
+			<name value="SNOMED.system" />
+			<short value="Identity of the terminology system" />
+			<definition value="The identification of the code system that defines the meaning of the symbol in the code." />
+			<comments value="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7&#39;s list of FHIR defined special URIs or it should de-reference to some definition that establish the system clearly and unambiguously." />
+			<requirements value="Need to be unambiguous about the source of the definition of the symbol." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Coding.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://snomed.info/sct" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.version" />
+			<name value="SNOMED.version" />
+			<short value="Version of the system - if relevant" />
+			<definition value="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured. and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." />
+			<comments value="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.version" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.code" />
+			<name value="SNOMED.code" />
+			<short value="Symbol in syntax defined by the system" />
+			<definition value="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to refer to a particular code in the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.code" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./code" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.display" />
+			<name value="SNOMED.display" />
+			<short value="Representation defined by the system" />
+			<definition value="A representation of the meaning of the code in the system, following the rules of the system." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to be able to carry a human-readable meaning of the code for readers that do not know  the system." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.2 - but note this is not well followed" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CV.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.coding.userSelected" />
+			<name value="SNOMED.userSelected" />
+			<short value="If this coding was chosen directly by the user" />
+			<definition value="Indicates that this coding was chosen by a user directly - i.e. off a pick list of available items (codes or displays)." />
+			<comments value="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly &#39;directly chosen&#39; implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely." />
+			<requirements value="This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Coding.userSelected" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Sometimes implied by being first" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD.codingRationale" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\#true a [     fhir:source &quot;true&quot;;     fhir:target dt:CDCoding.codingRationale\#O   ]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.priority.text" />
+			<short value="Plain text representation of the concept" />
+			<definition value="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user." />
+			<comments value="Very often the text is the same as a displayName of one of the codings." />
+			<requirements value="The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="CodeableConcept.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="C*E.9. But note many systems use C*E.2 for this" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./originalText[mediaType/code=&quot;text/plain&quot;]/data" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.patient" />
+			<short value="The patient present at the encounter" />
+			<definition value="The patient present at the encounter." />
+			<comments value="While the encounter is always about the patient, the patient may not actually be known in all contexts of use." />
+			<alias value="patient" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.patient" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".participation[typeCode=SBJ]/role[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="who.focus" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.episodeOfCare" />
+			<short value="Episode(s) of care that this encounter should be recorded against" />
+			<definition value="Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care, and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years)." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.episodeOfCare" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/EpisodeOfCare" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-54, PV1-53" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.incomingReferral" />
+			<short value="The ReferralRequest that initiated this encounter" />
+			<definition value="The referral request this encounter satisfies (incoming referral)." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.incomingReferral" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/ReferralRequest" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant" />
+			<short value="List of participants involved in the encounter" />
+			<definition value="The list of people responsible for providing the service." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.participant" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="ROL" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".participation[typeCode=PFM]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.type" />
+			<short value="Role of participant in encounter" />
+			<definition value="Role of participant in encounter." />
+			<comments value="The participant type indicates how an individual partitipates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.participant.type" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="Role of participant in encounter" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-participant-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="ROL-3 (or maybe PRT-4)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".functionCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.period" />
+			<short value="Period of time during the encounter participant was present" />
+			<definition value="The period of time that the specified participant was present during the encounter. These can overlap or be sub-sets of the overall encounters period." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.participant.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="ROL-5, ROL-6 (or maybe PRT-5)" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.participant.individual" />
+			<short value="Persons involved in the encounter other than the patient" />
+			<definition value="Persons involved in the encounter other than the patient." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.participant.individual" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="ROL-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".role" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="who" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.appointment" />
+			<short value="The appointment that scheduled this encounter" />
+			<definition value="The appointment that scheduled this encounter." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.appointment" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Appointment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="SCH-1 / SCH-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".outboundRelationship[typeCode=FLFS].target[classCode=ENC, moodCode=APT]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.period" />
+			<short value="The start and end time of the encounter" />
+			<definition value="The start and end time of the encounter." />
+			<comments value="If not (yet) known, the end of the Period may be omitted." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-44, PV1-45" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".effectiveTime (low &amp; high)" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="when.done" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.length" />
+			<short value="Quantity of time the encounter lasted (less time absent)" />
+			<definition value="Quantity of time the encounter lasted. This excludes the time during leaves of absence." />
+			<comments value="May differ from the time the Encounter.period lasted because of leave of absence." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.length" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Quantity" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Duration" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="qty-3" />
+				<severity value="error" />
+				<human value="If a code for the unit is present, the system SHALL also be present" />
+				<xpath value="not(exists(f:code)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="(PV1-45 less PV1-44) iff ( (PV1-44 not empty) and (PV1-45 not empty) ); units in minutes" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".lengthOfStayQuantity" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="SN (see also Range) or CQ" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="PQ, IVL&lt;PQ&gt;, MO, CO, depending on the values" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.reason" />
+			<short value="Reason the encounter takes place (code)" />
+			<definition value="Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis." />
+			<comments value="For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis)." />
+			<alias value="Indication" />
+			<alias value="Admission diagnosis" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.reason" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="Reason why the encounter takes place." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-reason" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".reasonCode" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="why" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.indication" />
+			<short value="Reason the encounter takes place (resource)" />
+			<definition value="Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure." />
+			<comments value="For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis)." />
+			<alias value="Admission diagnosis" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.indication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+			</type>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Procedure" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="Resources that would commonly referenced at Encounter.indication would be Condition and/or Procedure. These most closely align with DG1/PRB and PR1 respectively." />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".outboundRelationship[typeCode=RSON].target" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="why" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization" />
+			<short value="Details about the admission to a healthcare service" />
+			<definition value="Details about the admission to a healthcare service." />
+			<comments value="An Encounter may cover more than just the inpatient stay. Contexts such as outpatients, community clinics, and aged care facilities are also included.
+      The duration recorded in the period of this encounter covers the entire scope of this hospitalization record." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value=".outboundRelationship[typeCode=COMP].target[classCode=ENC, moodCode=EVN]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.preAdmissionIdentifier" />
+			<short value="Pre-admission identifier" />
+			<definition value="Pre-admission identifier." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.preAdmissionIdentifier" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.origin" />
+			<short value="The location from which the patient came before admission" />
+			<definition value="The location from which the patient came before admission." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.origin" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Location" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value=".participation[typeCode=ORG].role" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.admitSource" />
+			<short value="From where patient was admitted (physician referral, transfer)" />
+			<definition value="From where patient was admitted (physician referral, transfer)." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.admitSource" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="preferred" />
+				<description value="From where the patient was admitted." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-admit-source" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".admissionReferralSourceCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.admittingDiagnosis" />
+			<short value="The admitting diagnosis as reported by admitting practitioner" />
+			<definition value="The admitting diagnosis field is used to record the diagnosis codes as reported by admitting practitioner. This could be different or in addition to the conditions reported as reason-condition(s) for the encounter." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.hospitalization.admittingDiagnosis" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.reAdmission" />
+			<short value="The type of hospital re-admission that has occurred (if any). If the value is absent, then this is not identified as a readmission" />
+			<definition value="Whether this hospitalization is a readmission and why if known." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.reAdmission" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-13" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Propose at harmonization" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.dietPreference" />
+			<short value="Diet preferences reported by the patient" />
+			<definition value="Diet preferences reported by the patient." />
+			<comments value="For example a patient may request both a dairy-free and nut-free diet preference (not mutually exclusive)." />
+			<requirements value="Used to track patient&#39;s diet restrictions and/or preference. For a complete description of the nutrition needs of a patient during their stay, one should use the nutritionOrder resource which links to Encounter." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.hospitalization.dietPreference" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="Medical, cultural or ethical food preferences to help with catering requirements." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-diet" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-38" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".outboundRelationship[typeCode=COMP].target[classCode=SBADM, moodCode=EVN, code=&quot;diet&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.specialCourtesy" />
+			<short value="Special courtesies (VIP, board member)" />
+			<definition value="Special courtesies (VIP, board member)." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.hospitalization.specialCourtesy" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="preferred" />
+				<description value="Special courtesies" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-special-courtesy" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".specialCourtesiesCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.specialArrangement" />
+			<short value="Wheelchair, translator, stretcher, etc." />
+			<definition value="Wheelchair, translator, stretcher, etc." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.hospitalization.specialArrangement" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="preferred" />
+				<description value="Special arrangements" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-special-arrangements" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-15 / OBR-30 / OBR-43" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".specialArrangementCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.destination" />
+			<short value="Location to which the patient is discharged" />
+			<definition value="Location to which the patient is discharged." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.destination" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Location" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".participation[typeCode=DST]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.dischargeDisposition" />
+			<short value="Category or kind of location after discharge" />
+			<definition value="Category or kind of location after discharge." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.hospitalization.dischargeDisposition" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="preferred" />
+				<description value="Discharge Disposition" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-discharge-disposition" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-36" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".dischargeDispositionCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.hospitalization.dischargeDiagnosis" />
+			<short value="The final diagnosis given a patient before release from the hospital after all testing, surgery, and workup are complete" />
+			<definition value="The final diagnosis given a patient before release from the hospital after all testing, surgery, and workup are complete." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.hospitalization.dischargeDiagnosis" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value=".outboundRelationship[typeCode=OUT].target[classCode=OBS, moodCode=EVN, code=ASSERTION].value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location" />
+			<short value="List of locations where the patient has been" />
+			<definition value="List of locations where  the patient has been during this encounter." />
+			<comments value="Virtual encounters can be recorded in the Encounter by specifying a location reference to a location of type &quot;kind&quot; such as &quot;client&#39;s home&quot; and an encounter.class = &quot;virtual&quot;." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Encounter.location" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value=".participation[typeCode=LOC]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.location" />
+			<short value="Location the encounter takes place" />
+			<definition value="The location where the encounter takes place." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.location.location" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Location" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-3 / PV1-6 / PV1-11 / PV1-42 / PV1-43" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".role" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="where" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.status" />
+			<short value="planned | active | reserved | completed" />
+			<definition value="The status of the participants&#39; presence at the specified location during the period specified. If the participant is is no longer at the location, then the period will have an end date/time." />
+			<comments value="When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.location.status" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The status of the location." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/encounter-location-status" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.location.period" />
+			<short value="Time period during which the patient was present at the location" />
+			<definition value="Time period during which the patient was present at the location." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.location.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value=".time" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.serviceProvider" />
+			<short value="The custodian organization of this Encounter record" />
+			<definition value="An organization that is in charge of maintaining the information of this Encounter (e.g. who maintains the report or the master service catalog item, etc.). This MAY be the same as the organization on the Patient record, however it could be different. This MAY not be not the Service Delivery Location&#39;s Organization." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.serviceProvider" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PV1-10 / PL.6  &amp; PL.1  (note: HL7 v2 definition is &quot;the treatment or type of surgery that the patient is scheduled to receive&quot;; seems slightly out of alignment with the concept name &#39;hospital service&#39;. Would not trust that implementations apply this semantic by default)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".particiaption[typeCode=PFM].role" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Encounter.partOf" />
+			<short value="Another Encounter this encounter is part of" />
+			<definition value="Another Encounter of which this encounter is a part of (administratively or in time)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Encounter.partOf" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Encounter" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value=".inboundRelationship[typeCode=COMP].source[classCode=COMP, moodCode=EVN]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Encounter.type" />
+			<type>
+				<code value="CodeableConcept" />
+				<profile value="http://example.com/fhir/SD/codeable-with-systems" />
+			</type>
+		</element>
+		<element>
+			<path value="Encounter.priority" />
+			<type>
+				<code value="CodeableConcept" />
+				<profile value="http://example.com/fhir/SD/codeable-with-systems" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/organization-team-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/organization-team-profile.xml
@@ -1,0 +1,1097 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/organization-team" />
+	<name value="organization-team" />
+	<status value="draft" />
+	<description value="An organization of type &quot;team&quot;." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="servd" />
+		<uri value="http://www.omg.org/spec/ServD/1.0/" />
+		<name value="ServD" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Organization" />
+	<abstract value="false" />
+	<base value="http://hl7.org/fhir/StructureDefinition/Organization" />
+	<snapshot>
+		<element>
+			<path value="Organization" />
+			<short value="A grouping of people or organizations with a common purpose" />
+			<definition value="A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, etc." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="org-1" />
+				<severity value="error" />
+				<human value="The organization SHALL at least have a name or an id, and possibly more than one" />
+				<xpath value="count(f:identifier | f:name) &gt; 0" />
+			</constraint>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="(also see master files messages)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Organization(classCode=ORG, determinerCode=INST)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Organization" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.group" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.identifier" />
+			<short value="Identifies this organization  across multiple systems" />
+			<definition value="Identifier for the organization that is used to identify the organization across multiple disparate systems." />
+			<requirements value="Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="org-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XON.10 / XON.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".scopes[Role](classCode=IDENT)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Identifiers" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.active" />
+			<short value="Whether the organization&#39;s record is still in active use" />
+			<definition value="Whether the organization&#39;s record is still in active use." />
+			<comments value="Default is true." />
+			<requirements value="Need a flag to indicate a record is no longer to be used and should generally be hidden for the user in the UI." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="No equivalent in HL7 v2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".status" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Status (however this concept in ServD more covers why the organization is active or not, could be delisted, deregistered, not operational yet) this could alternatively be derived from ./StartDate and ./EndDate and given a context date." />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.type" />
+			<short value="Kind of organization" />
+			<definition value="The kind of organization that this is." />
+			<comments value="Organizations can be corporations, wards, sections, clinical teams, government departments, etc. Note that code is generally a classifier of the type of organization; in many applications, codes are used to identity a particular organization (say, ward) as opposed to another of the same type - these are identifiers, not codes." />
+			<requirements value="Need to be able to track the kind of organization that this is - different organization types have different uses." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Organization.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="Used to categorize the organization" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/organization-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="No equivalent in v2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".code" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="class" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.name" />
+			<short value="Name used for the organization" />
+			<definition value="A name associated with the organization." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Need to use the name as the label of the organization." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="org-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XON.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".name" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value=".PreferredName/Name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.telecom" />
+			<short value="A contact detail for the organization" />
+			<definition value="A contact detail for the organization." />
+			<comments value="The use code home is not to be used. Note that these contacts are not the contact details of people who are employed by or represent the organization, but official contacts for the organization itself." />
+			<requirements value="Human contact for the organization." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="org-3" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="org-3" />
+				<severity value="error" />
+				<human value="The telecom of an organization can never be of use &#39;home&#39;" />
+				<xpath value="count(f:use[@value=&#39;home&#39;]) = 0" />
+			</constraint>
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="ORC-22?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPoints" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.address" />
+			<short value="An address for the organization" />
+			<definition value="An address for the organization." />
+			<comments value="Organization may have multiple addresses with different uses or applicable periods. The use code home is not to be used." />
+			<requirements value="May need to keep track of the organization&#39;s addresses for contacting, billing or reporting requirements." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="org-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="org-2" />
+				<severity value="error" />
+				<human value="An address of an organization can never be of use &#39;home&#39;" />
+				<xpath value="count(f:use[@value=&#39;home&#39;]) = 0" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="ORC-23?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".address" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./PrimaryAddress and ./OtherAddresses" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.partOf" />
+			<short value="The organization of which this organization forms a part" />
+			<definition value="The organization of which this organization forms a part." />
+			<requirements value="Need to be able to track the hierarchy of organizations within an organization." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.partOf" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="No equivalent in HL7 v2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value=".playedBy[classCode=Part].scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact" />
+			<short value="Contact for the organization for a certain purpose" />
+			<definition value="Contact for the organization for a certain purpose." />
+			<comments value="Where multiple contacts for the same purpose are provided there is a standard extension that can be used to determine which one is the preferred contact to use." />
+			<requirements value="Need to keep track of assigned contact points within bigger organization." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value=".contactParty" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.purpose" />
+			<short value="The type of contact" />
+			<definition value="Indicates a purpose for which the contact can be reached." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Need to distinguish between multiple contact persons." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.contact.purpose" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The purpose for which you would contact a contact party" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contactentity-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="./type" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.name" />
+			<short value="A name associated with the contact" />
+			<definition value="A name associated with the contact." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Need to be able to track the person by name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.telecom" />
+			<short value="Contact details (telephone, email, etc.)  for a contact" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the party may be contacted." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Organization.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Organization.contact.address" />
+			<short value="Visiting or postal addresses for the contact" />
+			<definition value="Visiting or postal addresses for the contact." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="May need to keep track of a contact party&#39;s address for contacting, billing or reporting requirements." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Organization.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Organization.type" />
+			<min value="1" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-careprovider-type-reslice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-careprovider-type-reslice-profile.xml
@@ -1,0 +1,9246 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-careprovider-type-reslice" />
+	<name value="patient-careprovider-type-reslice" />
+	<status value="draft" />
+	<description value=" Re-slice a reference type slice." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://example.com/fhir/SD/patient-careprovider-type-slice" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="doNotCall" />
+			<short value="Do not call flag." />
+			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
+			<comments value="Comments for do not call flag root element." />
+			<requirements value="Requirements for do not call flag root element." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="doNotCall.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="doNotCall.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="legalCase" />
+			<label value="Legal Case Flag" />
+			<short value="Base for all elements" />
+			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="legalCase.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="legalCase.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].extension" />
+			<name value="legalCase.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean" />
+			<name value="legalCase.valueBoolean" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel" />
+			<label value="Lead Counsel" />
+			<short value="Base for all elements" />
+			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.value" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.value" />
+			<short value="Primitive value for boolean" />
+			<definition value="Primitive value for boolean" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="boolean.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="religion" />
+			<label value="Patient Religion" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="religion.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="religion.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="religion.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="religion.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Contact" />
+			</extension>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Animal" />
+			</extension>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare/teamCare" />
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://example.com/fhir/SD/organization-team" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare/teamCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare/teamCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare/teamCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare/teamCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="practitionerCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="practitionerCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="practitionerCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="practitionerCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare/teamCare" />
+			<type>
+				<code value="Reference" />
+				<profile value="http://example.com/fhir/SD/organization-team" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-careprovider-type-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-careprovider-type-slice-profile.xml
@@ -1,0 +1,9061 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-careprovider-type-slice" />
+	<name value="patient-careprovider-type-slice" />
+	<status value="draft" />
+	<description value="Slice a reference by type." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://example.com/fhir/SD/patient-deceasedDatetime-slice" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="doNotCall" />
+			<short value="Do not call flag." />
+			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
+			<comments value="Comments for do not call flag root element." />
+			<requirements value="Requirements for do not call flag root element." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="doNotCall.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="doNotCall.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="legalCase" />
+			<label value="Legal Case Flag" />
+			<short value="Base for all elements" />
+			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="legalCase.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="legalCase.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].extension" />
+			<name value="legalCase.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean" />
+			<name value="legalCase.valueBoolean" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel" />
+			<label value="Lead Counsel" />
+			<short value="Base for all elements" />
+			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.value" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.value" />
+			<short value="Primitive value for boolean" />
+			<definition value="Primitive value for boolean" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="boolean.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="religion" />
+			<label value="Patient Religion" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="religion.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="religion.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="religion.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="religion.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Contact" />
+			</extension>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Animal" />
+			</extension>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="practitionerCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="practitionerCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="practitionerCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="practitionerCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<short value="Care providers that are organizations." />
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-deceasedDatetime-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-deceasedDatetime-slice-profile.xml
@@ -1,8 +1,8 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-deceasedDatetime-slice" />
+	<name value="patient-deceasedDatetime-slice" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
+	<description value="Use a type named slicing (deceasedDate) of deceased[x]." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -32,7 +32,7 @@
 	<kind value="resource" />
 	<constrainedType value="Patient" />
 	<abstract value="false" />
-	<base value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<base value="http://example.com/fhir/SD/patient-telecom-slice" />
 	<snapshot>
 		<element>
 			<path value="Patient" />
@@ -3086,6 +3086,10 @@
 		</element>
 		<element>
 			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A name associated with the patient" />
 			<definition value="A name associated with the individual." />
 			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
@@ -3138,7 +3142,1237 @@
 			</mapping>
 		</element>
 		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
 			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A contact detail for the individual" />
 			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
 			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
@@ -3190,6 +4424,2108 @@
 			<mapping>
 				<identity value="servd" />
 				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -3301,8 +6637,116 @@
 				<max value="1" />
 			</base>
 			<type>
-				<code value="boolean" />
+				<code value="dateTime" />
 			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
 			<type>
 				<code value="dateTime" />
 			</type>
@@ -3331,6 +6775,88 @@
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
 		</element>
 		<element>
 			<path value="Patient.address" />
@@ -4992,53 +8518,16 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
+			<path value="Patient.deceased[x]" />
 			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+				<code value="dateTime" />
 			</type>
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
 			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+				<code value="dateTime" />
 			</type>
 		</element>
 	</differential>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-do-not-call-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-do-not-call-profile.xml
@@ -4,38 +4,20 @@
 	<display value="Do Not Call Flag" />
 	<status value="draft" />
 	<description value="Description for patient-do-not-call." />
-  
-  <!-- [WMR 20160810] Fixed
-	<fhirVersion value="1.4.0" />
-  -->
-  <fhirVersion value="1.0.2"/>
-  
-  <mapping>
+	<fhirVersion value="1.0.2" />
+	<mapping>
 		<identity value="rim" />
 		<uri value="http://hl7.org/v3" />
-		<name value="RIM Mapping" />
+		<name value="RIM" />
 	</mapping>
-  
-  <!-- [WMR 20160810] Fixed
-	<kind value="complex-type" />
-  -->
-  <kind value="datatype" />
-  
-  <abstract value="false" />
+	<kind value="datatype" />
+	<constrainedType value="Extension" />
+	<abstract value="false" />
 	<contextType value="resource" />
 	<context value="Patient" />
-
-  <!-- [WMR 20160810] Fixed
-	<baseType value="Extension" />
-	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-	<derivation value="constraint" />
-  -->
-  <constrainedType value="Extension"/>
-  <base value="http://hl7.org/fhir/StructureDefinition/Extension"/>
-
-
-  <snapshot>
-		<element id="Extension">
+	<base value="http://hl7.org/fhir/StructureDefinition/Extension" />
+	<snapshot>
+		<element>
 			<path value="Extension" />
 			<short value="Do not call flag." />
 			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
@@ -57,19 +39,7 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<constraint>
-				<key value="ext-1" />
-				<severity value="error" />
-				<human value="Must have either extensions or value[x], not both" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="extension.exists() != value.exists()" />
-        -->
-				<xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])" />
 			</constraint>
 			<mapping>
 				<identity value="rim" />
@@ -79,16 +49,13 @@
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
 		</element>
-		<element id="Extension.id">
+		<element>
 			<path value="Extension.id" />
 			<representation value="xmlAttr" />
 			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces." />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
 			<min value="0" />
 			<max value="1" />
 			<base>
@@ -97,14 +64,25 @@
 				<max value="1" />
 			</base>
 			<type>
-				<code value="string" />
+				<code value="id" />
 			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
 			<mapping>
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
 		</element>
-		<element id="Extension.extension">
+		<element>
 			<path value="Extension.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
@@ -126,19 +104,7 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<constraint>
-				<key value="ext-1" />
-				<severity value="error" />
-				<human value="Must have either extensions or value[x], not both" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="extension.exists() != value.exists()" />
-        -->
-				<xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])" />
 			</constraint>
 			<mapping>
 				<identity value="rim" />
@@ -152,17 +118,13 @@
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
 		</element>
-		<element id="Extension.url">
+		<element>
 			<path value="Extension.url" />
 			<representation value="xmlAttr" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
 			<min value="1" />
 			<max value="1" />
 			<base>
@@ -179,9 +141,6 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
 			<mapping>
@@ -193,7 +152,7 @@
 				<map value="n/a" />
 			</mapping>
 		</element>
-		<element id="Extension.value[x]">
+		<element>
 			<path value="Extension.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
@@ -212,9 +171,6 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-				<expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
 			<mapping>
@@ -228,7 +184,7 @@
 		</element>
 	</snapshot>
 	<differential>
-		<element id="Extension">
+		<element>
 			<path value="Extension" />
 			<short value="Do not call flag." />
 			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
@@ -236,11 +192,11 @@
 			<requirements value="Requirements for do not call flag root element." />
 			<alias value="no-contact-me-plz" />
 		</element>
-		<element id="Extension.url">
+		<element>
 			<path value="Extension.url" />
 			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
 		</element>
-		<element id="Extension.value[x]">
+		<element>
 			<path value="Extension.value[x]" />
 			<min value="1" />
 			<type>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-gender-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-gender-profile.xml
@@ -1,0 +1,2425 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-gender" />
+	<name value="patient-gender" />
+	<status value="draft" />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.implicitRules" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.contact" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.animal" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<max value="0" />
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<max value="0" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-id-site-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-id-site-profile.xml
@@ -1,7 +1,9 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-	<name value="patient-legal-case-lead-counsel" />
+	<url value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+	<name value="patient-id-site" />
+	<display value="Patient Identifier Issuing Site" />
 	<status value="draft" />
+	<description value="Coding for the authority who issued with patient identifier." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -11,14 +13,14 @@
 	<kind value="datatype" />
 	<constrainedType value="Extension" />
 	<abstract value="false" />
-	<contextType value="datatype" />
-	<context value="Extension.value[x]" />
+	<contextType value="resource" />
+	<context value="Patient.identifier" />
 	<base value="http://hl7.org/fhir/StructureDefinition/Extension" />
 	<snapshot>
 		<element>
 			<path value="Extension" />
-			<short value="Base for all elements" />
-			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
 			<min value="0" />
 			<max value="*" />
 			<base>
@@ -130,7 +132,7 @@
 			<type>
 				<code value="uri" />
 			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -264,6 +266,182 @@
 				<human value="All FHIR elements must have a @value or children" />
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Extension.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Extension.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Extension.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
 			<mapping>
 				<identity value="rim" />
 				<map value="N/A" />
@@ -277,15 +455,26 @@
 	<differential>
 		<element>
 			<path value="Extension" />
-			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<short value="Site code where an identifier was issued." />
 		</element>
 		<element>
 			<path value="Extension.url" />
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
 		</element>
 		<element>
 			<path value="Extension.value[x]" />
 			<min value="1" />
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+		</element>
+		<element>
+			<path value="Extension.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<type>
+				<code value="CodeableConcept" />
+			</type>
 		</element>
 	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-identifier-profile-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-identifier-profile-slice-profile.xml
@@ -1,0 +1,11574 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-slice-by-profile" />
+	<name value="patient-identifier-profile-slice" />
+	<display value="Slice Patient identifiers by profile" />
+	<status value="draft" />
+	<description value="An example profile where an element is sliced by profile (discriminator:&quot;@profile&quot;). Type profiles are created (outside this profile) by constraining the FHIR type. They are then applied to a named slice using the elementdefinition.type.profile element." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://example.com/fhir/SD/patient-careprovider-type-reslice" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="doNotCall" />
+			<short value="Do not call flag." />
+			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
+			<comments value="Comments for do not call flag root element." />
+			<requirements value="Requirements for do not call flag root element." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="doNotCall.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="doNotCall.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="legalCase" />
+			<label value="Legal Case Flag" />
+			<short value="Base for all elements" />
+			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="legalCase.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="legalCase.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].extension" />
+			<name value="legalCase.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean" />
+			<name value="legalCase.valueBoolean" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel" />
+			<label value="Lead Counsel" />
+			<short value="Base for all elements" />
+			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.value" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.value" />
+			<short value="Primitive value for boolean" />
+			<definition value="Primitive value for boolean" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="boolean.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="religion" />
+			<label value="Patient Religion" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="religion.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="religion.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="religion.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="religion.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<label value="Medical Record Number" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn/officialMRN" />
+			<label value="Medical Record Number" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn/officialMRN.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn/officialMRN.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn/officialMRN.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn/officialMRN.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn/officialMRN.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn/officialMRN.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn/officialMRN.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn/officialMRN.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mdmId" />
+			<label value="Master Patient Id" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mdm-id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.issuingSite.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.issuingSite.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].extension" />
+			<name value="mdmId.issuingSite.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept" />
+			<name value="mdmId.issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.extension" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mdmId.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mdmId.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mdmId.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MDM" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mdmId.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mdmId.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mdmId.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Contact" />
+			</extension>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Animal" />
+			</extension>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare/teamCare" />
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://example.com/fhir/SD/organization-team" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare/teamCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare/teamCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare/teamCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare/teamCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="practitionerCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="practitionerCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="practitionerCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="practitionerCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<label value="Medical Record Number" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
+			</type>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn/officialMRN.use" />
+			<fixedCode value="official" />
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mdmId" />
+			<label value="Master Patient Id" />
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mdm-id" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-identifier-slice-extension-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-identifier-slice-extension-profile.xml
@@ -1,0 +1,12225 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-identifier-subslice" />
+	<name value="patient-identifier-slice-extension" />
+	<display value="Patient with Subslice" />
+	<status value="draft" />
+	<description value="This profile demonstrates a profile with an extension applicable to only one slice of an element.  Here, issuingSite is applicable only to MRNs (as sliced by identifier.system)." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://example.com/fhir/SD/patient-slice-by-profile" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="doNotCall" />
+			<short value="Do not call flag." />
+			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
+			<comments value="Comments for do not call flag root element." />
+			<requirements value="Requirements for do not call flag root element." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="doNotCall.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="doNotCall.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="legalCase" />
+			<label value="Legal Case Flag" />
+			<short value="Base for all elements" />
+			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="legalCase.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="legalCase.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].extension" />
+			<name value="legalCase.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean" />
+			<name value="legalCase.valueBoolean" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel" />
+			<label value="Lead Counsel" />
+			<short value="Base for all elements" />
+			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.value" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.value" />
+			<short value="Primitive value for boolean" />
+			<definition value="Primitive value for boolean" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="boolean.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="religion" />
+			<label value="Patient Religion" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="religion.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="religion.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="religion.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="religion.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="2" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<label value="Medical Record Number" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mrn.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mrn.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mrn.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mrn.issuingSite.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mrn.issuingSite.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].extension" />
+			<name value="mrn.issuingSite.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept" />
+			<name value="mrn.issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.extension" />
+			<name value="mrn.issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn/officialMRN" />
+			<label value="Medical Record Number" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn/officialMRN.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn/officialMRN.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn/officialMRN.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn/officialMRN.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn/officialMRN.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn/officialMRN.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn/officialMRN.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn/officialMRN.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mdmId" />
+			<label value="Master Patient Id" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mdm-id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.issuingSite.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.issuingSite.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].extension" />
+			<name value="mdmId.issuingSite.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept" />
+			<name value="mdmId.issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.extension" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mdmId.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mdmId.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mdmId.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MDM" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mdmId.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mdmId.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mdmId.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Contact" />
+			</extension>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Animal" />
+			</extension>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare/teamCare" />
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://example.com/fhir/SD/organization-team" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare/teamCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare/teamCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare/teamCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare/teamCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="practitionerCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="practitionerCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="practitionerCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="practitionerCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<max value="2" />
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.issuingSite" />
+			<min value="1" />
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-legal-case-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-legal-case-profile.xml
@@ -2,37 +2,20 @@
 	<url value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
 	<name value="patient-legal-case" />
 	<status value="draft" />
-  
-  <!-- [WMR 20160810] Fixed
-	<fhirVersion value="1.4.0" />
-  -->
-  <fhirVersion value="1.0.2"/>
-  
-  <mapping>
+	<fhirVersion value="1.0.2" />
+	<mapping>
 		<identity value="rim" />
 		<uri value="http://hl7.org/v3" />
-		<name value="RIM Mapping" />
+		<name value="RIM" />
 	</mapping>
-
-  <!-- [WMR 20160810] Fixed
-	<kind value="complex-type" />
-  -->
-  <kind value="datatype" />
-
-  <abstract value="false" />
+	<kind value="datatype" />
+	<constrainedType value="Extension" />
+	<abstract value="false" />
 	<contextType value="resource" />
 	<context value="Patient" />
-
-  <!-- [WMR 20160810] Fixed
-  <baseType value="Extension" />
-	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-	<derivation value="constraint" />
-  -->
-  <constrainedType value="Extension"/>
-  <base value="http://hl7.org/fhir/StructureDefinition/Extension"/>
-
-  <snapshot>
-		<element id="Extension">
+	<base value="http://hl7.org/fhir/StructureDefinition/Extension" />
+	<snapshot>
+		<element>
 			<path value="Extension" />
 			<short value="Base for all elements" />
 			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
@@ -51,19 +34,7 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-        <expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<constraint>
-				<key value="ext-1" />
-				<severity value="error" />
-				<human value="Must have either extensions or value[x], not both" />
-				<!-- [WMR 20160810] Fixed
-        <expression value="extension.exists() != value.exists()" />
-        -->
-				<xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])" />
 			</constraint>
 			<mapping>
 				<identity value="rim" />
@@ -73,16 +44,13 @@
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
 		</element>
-		<element id="Extension.id">
+		<element>
 			<path value="Extension.id" />
 			<representation value="xmlAttr" />
 			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces." />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
 			<min value="0" />
 			<max value="1" />
 			<base>
@@ -91,14 +59,25 @@
 				<max value="1" />
 			</base>
 			<type>
-				<code value="string" />
+				<code value="id" />
 			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
 			<mapping>
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
 		</element>
-		<element id="Extension.extension">
+		<element>
 			<path value="Extension.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
@@ -120,19 +99,7 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-        <expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<constraint>
-				<key value="ext-1" />
-				<severity value="error" />
-				<human value="Must have either extensions or value[x], not both" />
-        <!-- [WMR 20160810] Fixed
-        <expression value="extension.exists() != value.exists()" />
-        -->
-				<xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), &#39;value&#39;)])" />
 			</constraint>
 			<mapping>
 				<identity value="rim" />
@@ -146,17 +113,13 @@
 				<identity value="rim" />
 				<map value="n/a" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
 		</element>
-		<element id="Extension.url">
+		<element>
 			<path value="Extension.url" />
 			<representation value="xmlAttr" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
 			<min value="1" />
 			<max value="1" />
 			<base>
@@ -173,9 +136,6 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-				<!-- [WMR 20160810] Fixed
-        <expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
 			<mapping>
@@ -187,7 +147,7 @@
 				<map value="n/a" />
 			</mapping>
 		</element>
-		<element id="Extension.value[x]">
+		<element>
 			<path value="Extension.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
@@ -206,9 +166,6 @@
 				<key value="ele-1" />
 				<severity value="error" />
 				<human value="All FHIR elements must have a @value or children" />
-        <!-- [WMR 20160810] Fixed
-        <expression value="children().count() &gt; id.count()" />
-        -->
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
 			<mapping>
@@ -222,15 +179,15 @@
 		</element>
 	</snapshot>
 	<differential>
-		<element id="Extension">
+		<element>
 			<path value="Extension" />
 			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
 		</element>
-		<element id="Extension.url">
+		<element>
 			<path value="Extension.url" />
 			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
 		</element>
-		<element id="Extension.value[x]">
+		<element>
 			<path value="Extension.value[x]" />
 			<min value="1" />
 			<type>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-mdm-id-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-mdm-id-profile.xml
@@ -1,33 +1,43 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-	<name value="patient-research-authorization" />
+	<url value="http://example.com/fhir/SD/patient-mdm-id" />
+	<name value="patient-mdm-id" />
 	<status value="draft" />
+	<description value="An example type profile constraining the Identifier type. For use in slicing by profile examples." />
 	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
 	<mapping>
 		<identity value="rim" />
 		<uri value="http://hl7.org/v3" />
 		<name value="RIM" />
 	</mapping>
+	<mapping>
+		<identity value="servd" />
+		<uri value="http://www.omg.org/spec/ServD/1.0/" />
+		<name value="ServD" />
+	</mapping>
 	<kind value="datatype" />
-	<constrainedType value="Extension" />
+	<constrainedType value="Identifier" />
 	<abstract value="false" />
-	<contextType value="resource" />
-	<context value="Patient" />
-	<base value="http://hl7.org/fhir/StructureDefinition/Extension" />
+	<base value="http://hl7.org/fhir/StructureDefinition/Identifier" />
 	<snapshot>
 		<element>
-			<path value="Extension" />
-			<short value="Base for all elements" />
-			<definition value="Record of the patients general research authorization status." />
+			<path value="Identifier" />
+			<label value="MDM Identifier" />
+			<short value="An identifier intended for computation" />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
 			<min value="0" />
 			<max value="*" />
 			<base>
-				<path value="Extension" />
+				<path value="Identifier" />
 				<min value="0" />
 				<max value="*" />
 			</base>
 			<type>
-				<code value="Extension" />
+				<code value="Identifier" />
 			</type>
 			<condition value="ele-1" />
 			<constraint>
@@ -36,9 +46,18 @@
 				<human value="All FHIR elements must have a @value or children" />
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
 			<mapping>
 				<identity value="rim" />
-				<map value="N/A" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -46,7 +65,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.id" />
+			<path value="Identifier.id" />
 			<representation value="xmlAttr" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
@@ -78,7 +97,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension" />
+			<path value="Identifier.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -113,7 +132,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.id" />
+			<path value="Identifier.extension.id" />
 			<representation value="xmlAttr" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
@@ -145,7 +164,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.extension" />
+			<path value="Identifier.extension.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -182,7 +201,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.url" />
+			<path value="Identifier.extension.url" />
 			<representation value="xmlAttr" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
@@ -214,7 +233,7 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.value[x]" />
+			<path value="Identifier.extension.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
 			<min value="0" />
@@ -340,13 +359,12 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension" />
-			<name value="type" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="1" />
-			<max value="1" />
+			<path value="Identifier.extension" />
+			<name value="issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="0" />
+			<max value="*" />
 			<base>
 				<path value="Element.extension" />
 				<min value="0" />
@@ -354,6 +372,7 @@
 			</base>
 			<type>
 				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
 			</type>
 			<condition value="ele-1" />
 			<constraint>
@@ -364,11 +383,11 @@
 			</constraint>
 			<mapping>
 				<identity value="rim" />
-				<map value="n/a" />
+				<map value="N/A" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
-				<map value="N/A" />
+				<map value="n/a" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -376,9 +395,9 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.id" />
+			<path value="Identifier.extension.id" />
 			<representation value="xmlAttr" />
-			<name value="type.id" />
+			<name value="issuingSite.id" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
 			<comments value="RFC 4122" />
@@ -409,8 +428,8 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.extension" />
-			<name value="type.extension" />
+			<path value="Identifier.extension.extension" />
+			<name value="issuingSite.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -447,9 +466,9 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.url" />
+			<path value="Identifier.extension.url" />
 			<representation value="xmlAttr" />
-			<name value="type.url" />
+			<name value="issuingSite.url" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
 			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
@@ -463,7 +482,7 @@
 			<type>
 				<code value="uri" />
 			</type>
-			<fixedUri value="type" />
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -481,180 +500,8 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="type.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="code" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension" />
-			<name value="flag" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="flag.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.extension" />
-			<name value="flag.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="flag.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="flag" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="flag.value[x]" />
+			<path value="Identifier.extension.value[x]" />
+			<name value="issuingSite.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
 			<min value="1" />
@@ -770,6 +617,10 @@
 				<human value="All FHIR elements must have a @value or children" />
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
 			<mapping>
 				<identity value="rim" />
 				<map value="N/A" />
@@ -780,45 +631,9 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension" />
-			<name value="date" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.id" />
+			<path value="Identifier.extension.value[x].id" />
 			<representation value="xmlAttr" />
-			<name value="date.id" />
+			<name value="issuingSite.value[x].id" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
 			<comments value="RFC 4122" />
@@ -849,8 +664,8 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.extension" />
-			<name value="date.extension" />
+			<path value="Identifier.extension.value[x].extension" />
+			<name value="issuingSite.value[x].extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -887,43 +702,9 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="date.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="date" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="date.value[x]" />
-			<short value="Value of extension" />
+			<path value="Identifier.extension.valueCodeableConcept" />
+			<name value="issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
 			<min value="1" />
 			<max value="1" />
@@ -933,104 +714,8 @@
 				<max value="1" />
 			</base>
 			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
 				<code value="CodeableConcept" />
 			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -1038,6 +723,10 @@
 				<human value="All FHIR elements must have a @value or children" />
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
 			<mapping>
 				<identity value="rim" />
 				<map value="N/A" />
@@ -1048,147 +737,21 @@
 			</mapping>
 		</element>
 		<element>
-			<path value="Extension.url" />
+			<path value="Identifier.extension.valueCodeableConcept.id" />
 			<representation value="xmlAttr" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<name value="issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
 			<min value="0" />
 			<max value="1" />
 			<base>
-				<path value="Extension.value[x]" />
+				<path value="Element.id" />
 				<min value="0" />
 				<max value="1" />
 			</base>
 			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
 				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
 			</type>
 			<condition value="ele-1" />
 			<constraint>
@@ -1199,7 +762,332 @@
 			</constraint>
 			<mapping>
 				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.extension.valueCodeableConcept.extension" />
+			<name value="issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
 				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MDM" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -1209,68 +1097,21 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Extension" />
-			<definition value="Record of the patients general research authorization status." />
+			<path value="Identifier" />
+			<label value="MDM Identifier" />
 		</element>
-    <!-- [WMR 20160917] Invalid order!
 		<element>
-			<path value="Extension.url" />
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-		</element>
-    -->
-		<element>
-			<path value="Extension.extension" />
-			<name value="type" />
+			<path value="Identifier.system" />
 			<min value="1" />
-			<max value="1" />
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MDM" />
 		</element>
 		<element>
-			<path value="Extension.extension.url" />
-			<name value="type.url" />
-			<fixedUri value="type" />
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="type.value[x]" />
-			<min value="1" />
+			<path value="Identifier.extension" />
+			<name value="issuingSite" />
 			<type>
-				<code value="code" />
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
 			</type>
 		</element>
-		<element>
-			<path value="Extension.extension" />
-			<name value="flag" />
-			<max value="1" />
-		</element>
-		<element>
-			<path value="Extension.extension.url" />
-			<name value="flag.url" />
-			<fixedUri value="flag" />
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="flag.value[x]" />
-			<min value="1" />
-		</element>
-		<element>
-			<path value="Extension.extension" />
-			<name value="date" />
-			<max value="1" />
-		</element>
-		<element>
-			<path value="Extension.extension.url" />
-			<name value="date.url" />
-			<fixedUri value="date" />
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="date.value[x]" />
-			<min value="1" />
-		</element>
-    <!-- [WMR 20160917] Fixed order -->
-    <element>
-      <path value="Extension.url" />
-      <fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-    </element>
-  </differential>
+	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-mrn-id-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-mrn-id-profile.xml
@@ -1,0 +1,434 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-mrn-id" />
+	<name value="patient-mrn-id" />
+	<status value="draft" />
+	<description value="An example type profile constraining the Identifier type. For use in slicing by profile examples." />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="servd" />
+		<uri value="http://www.omg.org/spec/ServD/1.0/" />
+		<name value="ServD" />
+	</mapping>
+	<kind value="datatype" />
+	<constrainedType value="Identifier" />
+	<abstract value="false" />
+	<base value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+	<snapshot>
+		<element>
+			<path value="Identifier" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Identifier" />
+			<short value="A medical record number." />
+		</element>
+		<element>
+			<path value="Identifier.system" />
+			<min value="1" />
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-name-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-name-slice-profile.xml
@@ -1,8 +1,8 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-name-slice" />
+	<name value="patient-name-slice" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
+	<description value="Slice Patient.name by a single fixed value." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -32,7 +32,7 @@
 	<kind value="resource" />
 	<constrainedType value="Patient" />
 	<abstract value="false" />
-	<base value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<base value="http://example.com/fhir/SD/patient-with-extensions" />
 	<snapshot>
 		<element>
 			<path value="Patient" />
@@ -3086,6 +3086,10 @@
 		</element>
 		<element>
 			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A name associated with the patient" />
 			<definition value="A name associated with the individual." />
 			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
@@ -3131,6 +3135,1231 @@
 			<mapping>
 				<identity value="servd" />
 				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -4992,54 +6221,48 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<max value="1" />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<min value="1" />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<min value="1" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<min value="1" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			</type>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<min value="1" />
+			<fixedCode value="official" />
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<min value="1" />
+			<fixedCode value="maiden" />
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<min value="1" />
 		</element>
 	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-only-mrn-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-only-mrn-profile.xml
@@ -1,8 +1,8 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-only-mrn" />
+	<name value="patient-only-mrn" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
+	<description value="Only allow MRNs by limiting the type.profile." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -281,6 +281,8 @@
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
 			<min value="0" />
 			<max value="*" />
 			<base>
@@ -302,2642 +304,6 @@
 				<identity value="rim" />
 				<map value="N/A" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<short value="Do not call flag." />
-			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
-			<comments value="Comments for do not call flag root element." />
-			<requirements value="Requirements for do not call flag root element." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="doNotCall.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="doNotCall.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="doNotCall.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="doNotCall.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<short value="Base for all elements" />
-			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="legalCase.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="legalCase.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x].id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.value[x].id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x].extension" />
-			<name value="legalCase.value[x].extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.extension.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.extension" />
-			<name value="legalCase.valueBoolean.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.extension.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.value[x]" />
-			<name value="legalCase.valueBoolean.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<short value="Base for all elements" />
-			<definition value="Identification of the the legal counsel assigned to the case in question." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.leadCounsel.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.leadCounsel.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.value[x]" />
-			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.value" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.value" />
-			<short value="Primitive value for boolean" />
-			<definition value="Primitive value for boolean" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="boolean.value" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<short value="Patient&#39;s professed religious affiliation" />
-			<definition value="A code classifying a person&#39;s professed religion." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="religion.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="religion.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="0" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="religion.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="religion.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<binding>
-				<strength value="required" />
-				<description value="A code classifying a person&#39;s professed religion" />
-				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
-			</binding>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<short value="Base for all elements" />
-			<definition value="Record of the patients general research authorization status." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.extension.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.extension.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.type" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.type.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.type.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.type.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="type" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.type.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="code" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.flag" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.flag.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.flag.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.flag.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="flag" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.flag.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.date" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.date.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.date.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.date.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="date" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.date.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="researchAuth.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
 			<mapping>
 				<identity value="rim" />
 				<map value="N/A" />
@@ -2990,7 +356,7 @@
 			<short value="An identifier for this patient" />
 			<definition value="An identifier for this patient." />
 			<requirements value="Patients are almost always assigned specific numerical identifiers." />
-			<min value="0" />
+			<min value="1" />
 			<max value="*" />
 			<base>
 				<path value="Patient.identifier" />
@@ -2999,6 +365,7 @@
 			</base>
 			<type>
 				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
 			</type>
 			<condition value="ele-1" />
 			<constraint>
@@ -3008,6 +375,22 @@
 				<xpath value="@value|f:*|h:div" />
 			</constraint>
 			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
 			<mapping>
 				<identity value="v2" />
 				<map value="PID-3" />
@@ -3024,17 +407,357 @@
 				<identity value="w5" />
 				<map value="id" />
 			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
 			<mapping>
-				<identity value="v2" />
-				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+				<identity value="rim" />
+				<map value="n/a" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
-				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
 			</mapping>
 			<mapping>
 				<identity value="servd" />
-				<map value="Identifier" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -4992,53 +2715,11 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
+			<path value="Patient.identifier" />
+			<min value="1" />
 			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
 			</type>
 		</element>
 	</differential>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-only-mrn-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-only-mrn-slice-profile.xml
@@ -1,8 +1,8 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-only-mrn-slice" />
+	<name value="patient-only-mrn-slice" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
+	<description value="A profile with all elements removed _except_ one slice of identifer (mrn). Closed slicing." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -281,6 +281,8 @@
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
 			<min value="0" />
 			<max value="*" />
 			<base>
@@ -302,2642 +304,6 @@
 				<identity value="rim" />
 				<map value="N/A" />
 			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<short value="Do not call flag." />
-			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
-			<comments value="Comments for do not call flag root element." />
-			<requirements value="Requirements for do not call flag root element." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="doNotCall.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="doNotCall.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="doNotCall.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="doNotCall.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<short value="Base for all elements" />
-			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="legalCase.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="legalCase.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x].id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.value[x].id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x].extension" />
-			<name value="legalCase.value[x].extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.extension.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.extension" />
-			<name value="legalCase.valueBoolean.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.extension.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.value[x]" />
-			<name value="legalCase.valueBoolean.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<short value="Base for all elements" />
-			<definition value="Identification of the the legal counsel assigned to the case in question." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.leadCounsel.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.leadCounsel.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension.value[x]" />
-			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.value" />
-			<representation value="xmlAttr" />
-			<name value="legalCase.valueBoolean.value" />
-			<short value="Primitive value for boolean" />
-			<definition value="Primitive value for boolean" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="boolean.value" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<short value="Patient&#39;s professed religious affiliation" />
-			<definition value="A code classifying a person&#39;s professed religion." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="religion.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="religion.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="0" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="religion.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="religion.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<binding>
-				<strength value="required" />
-				<description value="A code classifying a person&#39;s professed religion" />
-				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
-			</binding>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<short value="Base for all elements" />
-			<definition value="Record of the patients general research authorization status." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="DomainResource.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.extension.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.extension.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.extension.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.extension.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.type" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.type.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.type.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.type.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="type" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.type.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="code" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.flag" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.flag.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.flag.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.flag.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="flag" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.flag.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension" />
-			<name value="researchAuth.date" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.date.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.extension" />
-			<name value="researchAuth.date.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.date.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="date" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.extension.value[x]" />
-			<name value="researchAuth.date.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="researchAuth.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Patient.extension.value[x]" />
-			<name value="researchAuth.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="boolean" />
-			</type>
-			<type>
-				<code value="integer" />
-			</type>
-			<type>
-				<code value="decimal" />
-			</type>
-			<type>
-				<code value="base64Binary" />
-			</type>
-			<type>
-				<code value="instant" />
-			</type>
-			<type>
-				<code value="string" />
-			</type>
-			<type>
-				<code value="uri" />
-			</type>
-			<type>
-				<code value="date" />
-			</type>
-			<type>
-				<code value="dateTime" />
-			</type>
-			<type>
-				<code value="time" />
-			</type>
-			<type>
-				<code value="code" />
-			</type>
-			<type>
-				<code value="oid" />
-			</type>
-			<type>
-				<code value="id" />
-			</type>
-			<type>
-				<code value="unsignedInt" />
-			</type>
-			<type>
-				<code value="positiveInt" />
-			</type>
-			<type>
-				<code value="markdown" />
-			</type>
-			<type>
-				<code value="Annotation" />
-			</type>
-			<type>
-				<code value="Attachment" />
-			</type>
-			<type>
-				<code value="Identifier" />
-			</type>
-			<type>
-				<code value="CodeableConcept" />
-			</type>
-			<type>
-				<code value="Coding" />
-			</type>
-			<type>
-				<code value="Quantity" />
-			</type>
-			<type>
-				<code value="Range" />
-			</type>
-			<type>
-				<code value="Period" />
-			</type>
-			<type>
-				<code value="Ratio" />
-			</type>
-			<type>
-				<code value="SampledData" />
-			</type>
-			<type>
-				<code value="Signature" />
-			</type>
-			<type>
-				<code value="Reference" />
-			</type>
-			<type>
-				<code value="HumanName" />
-			</type>
-			<type>
-				<code value="Address" />
-			</type>
-			<type>
-				<code value="ContactPoint" />
-			</type>
-			<type>
-				<code value="Timing" />
-			</type>
-			<type>
-				<code value="Meta" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
 			<mapping>
 				<identity value="rim" />
 				<map value="N/A" />
@@ -2987,6 +353,10 @@
 		</element>
 		<element>
 			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="closed" />
+			</slicing>
 			<short value="An identifier for this patient" />
 			<definition value="An identifier for this patient." />
 			<requirements value="Patients are almost always assigned specific numerical identifiers." />
@@ -3035,6 +405,783 @@
 			<mapping>
 				<identity value="servd" />
 				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -4992,53 +3139,19 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="closed" />
+			</slicing>
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<min value="1" />
 			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
-		</element>
-		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mrn-id" />
 			</type>
 		</element>
 	</differential>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-research-auth-algorithm-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-research-auth-algorithm-profile.xml
@@ -1,6 +1,6 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-	<name value="patient-research-authorization" />
+	<url value="http://example.com/fhir/StructureDefinition/patient-research-auth-algorithm" />
+	<name value="patient-research-auth-algorithm" />
 	<status value="draft" />
 	<fhirVersion value="1.0.2" />
 	<mapping>
@@ -11,14 +11,15 @@
 	<kind value="datatype" />
 	<constrainedType value="Extension" />
 	<abstract value="false" />
-	<contextType value="resource" />
-	<context value="Patient" />
+	<contextType value="datatype" />
+	<context value="Extension.extension" />
+	<context value="Extension" />
 	<base value="http://hl7.org/fhir/StructureDefinition/Extension" />
 	<snapshot>
 		<element>
 			<path value="Extension" />
 			<short value="Base for all elements" />
-			<definition value="Record of the patients general research authorization status." />
+			<definition value="Optional Extensions Element - found in all resources." />
 			<min value="0" />
 			<max value="*" />
 			<base>
@@ -341,7 +342,7 @@
 		</element>
 		<element>
 			<path value="Extension.extension" />
-			<name value="type" />
+			<name value="name" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -378,7 +379,7 @@
 		<element>
 			<path value="Extension.extension.id" />
 			<representation value="xmlAttr" />
-			<name value="type.id" />
+			<name value="name.id" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
 			<comments value="RFC 4122" />
@@ -410,7 +411,7 @@
 		</element>
 		<element>
 			<path value="Extension.extension.extension" />
-			<name value="type.extension" />
+			<name value="name.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -449,7 +450,7 @@
 		<element>
 			<path value="Extension.extension.url" />
 			<representation value="xmlAttr" />
-			<name value="type.url" />
+			<name value="name.url" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
 			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
@@ -463,7 +464,7 @@
 			<type>
 				<code value="uri" />
 			</type>
-			<fixedUri value="type" />
+			<fixedUri value="name" />
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -482,179 +483,7 @@
 		</element>
 		<element>
 			<path value="Extension.extension.value[x]" />
-			<name value="type.value[x]" />
-			<short value="Value of extension" />
-			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.value[x]" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="code" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension" />
-			<name value="flag" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.id" />
-			<representation value="xmlAttr" />
-			<name value="flag.id" />
-			<short value="xml:id (or equivalent in JSON)" />
-			<definition value="unique id for the element within a resource (for internal references)." />
-			<comments value="RFC 4122" />
-			<min value="0" />
-			<max value="1" />
-			<base>
-				<path value="Element.id" />
-				<min value="0" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="id" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.extension" />
-			<name value="flag.extension" />
-			<short value="Additional Content defined by implementations" />
-			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
-			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
-			<alias value="extensions" />
-			<alias value="user content" />
-			<min value="0" />
-			<max value="*" />
-			<base>
-				<path value="Element.extension" />
-				<min value="0" />
-				<max value="*" />
-			</base>
-			<type>
-				<code value="Extension" />
-			</type>
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.url" />
-			<representation value="xmlAttr" />
-			<name value="flag.url" />
-			<short value="identifies the meaning of the extension" />
-			<definition value="Source of the definition for the extension code - a logical name or a URL." />
-			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
-			<min value="1" />
-			<max value="1" />
-			<base>
-				<path value="Extension.url" />
-				<min value="1" />
-				<max value="1" />
-			</base>
-			<type>
-				<code value="uri" />
-			</type>
-			<fixedUri value="flag" />
-			<condition value="ele-1" />
-			<constraint>
-				<key value="ele-1" />
-				<severity value="error" />
-				<human value="All FHIR elements must have a @value or children" />
-				<xpath value="@value|f:*|h:div" />
-			</constraint>
-			<mapping>
-				<identity value="rim" />
-				<map value="N/A" />
-			</mapping>
-			<mapping>
-				<identity value="rim" />
-				<map value="n/a" />
-			</mapping>
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="flag.value[x]" />
+			<name value="name.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
 			<min value="1" />
@@ -781,7 +610,7 @@
 		</element>
 		<element>
 			<path value="Extension.extension" />
-			<name value="date" />
+			<name value="version" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -818,7 +647,7 @@
 		<element>
 			<path value="Extension.extension.id" />
 			<representation value="xmlAttr" />
-			<name value="date.id" />
+			<name value="version.id" />
 			<short value="xml:id (or equivalent in JSON)" />
 			<definition value="unique id for the element within a resource (for internal references)." />
 			<comments value="RFC 4122" />
@@ -850,7 +679,7 @@
 		</element>
 		<element>
 			<path value="Extension.extension.extension" />
-			<name value="date.extension" />
+			<name value="version.extension" />
 			<short value="Additional Content defined by implementations" />
 			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
 			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
@@ -889,7 +718,7 @@
 		<element>
 			<path value="Extension.extension.url" />
 			<representation value="xmlAttr" />
-			<name value="date.url" />
+			<name value="version.url" />
 			<short value="identifies the meaning of the extension" />
 			<definition value="Source of the definition for the extension code - a logical name or a URL." />
 			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
@@ -903,7 +732,7 @@
 			<type>
 				<code value="uri" />
 			</type>
-			<fixedUri value="date" />
+			<fixedUri value="version" />
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -922,10 +751,10 @@
 		</element>
 		<element>
 			<path value="Extension.extension.value[x]" />
-			<name value="date.value[x]" />
+			<name value="version.value[x]" />
 			<short value="Value of extension" />
 			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
-			<min value="1" />
+			<min value="0" />
 			<max value="1" />
 			<base>
 				<path value="Extension.value[x]" />
@@ -1063,7 +892,7 @@
 			<type>
 				<code value="uri" />
 			</type>
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<fixedUri value="http://example.com/fhir/StructureDefinition/algorithm" />
 			<condition value="ele-1" />
 			<constraint>
 				<key value="ele-1" />
@@ -1209,68 +1038,34 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Extension" />
-			<definition value="Record of the patients general research authorization status." />
-		</element>
-    <!-- [WMR 20160917] Invalid order!
-		<element>
 			<path value="Extension.url" />
-			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<fixedUri value="http://example.com/fhir/StructureDefinition/algorithm" />
 		</element>
-    -->
 		<element>
 			<path value="Extension.extension" />
-			<name value="type" />
+			<name value="name" />
 			<min value="1" />
 			<max value="1" />
 		</element>
 		<element>
 			<path value="Extension.extension.url" />
-			<name value="type.url" />
-			<fixedUri value="type" />
+			<name value="name.url" />
+			<fixedUri value="name" />
 		</element>
 		<element>
 			<path value="Extension.extension.value[x]" />
-			<name value="type.value[x]" />
-			<min value="1" />
-			<type>
-				<code value="code" />
-			</type>
-		</element>
-		<element>
-			<path value="Extension.extension" />
-			<name value="flag" />
-			<max value="1" />
-		</element>
-		<element>
-			<path value="Extension.extension.url" />
-			<name value="flag.url" />
-			<fixedUri value="flag" />
-		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="flag.value[x]" />
+			<name value="name.value[x]" />
 			<min value="1" />
 		</element>
 		<element>
 			<path value="Extension.extension" />
-			<name value="date" />
+			<name value="version" />
 			<max value="1" />
 		</element>
 		<element>
 			<path value="Extension.extension.url" />
-			<name value="date.url" />
-			<fixedUri value="date" />
+			<name value="version.url" />
+			<fixedUri value="version" />
 		</element>
-		<element>
-			<path value="Extension.extension.value[x]" />
-			<name value="date.value[x]" />
-			<min value="1" />
-		</element>
-    <!-- [WMR 20160917] Fixed order -->
-    <element>
-      <path value="Extension.url" />
-      <fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-    </element>
-  </differential>
+	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-research-auth-reslice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-research-auth-reslice-profile.xml
@@ -1,0 +1,13427 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/SD/patient-research-auth-reslice" />
+	<name value="patient-research-auth-reslice" />
+	<status value="draft" />
+	<fhirVersion value="1.0.2" />
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM" />
+	</mapping>
+	<mapping>
+		<identity value="cda" />
+		<uri value="http://hl7.org/v3/cda" />
+		<name value="CDA (R2)" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/w5" />
+		<name value="W5 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2" />
+	</mapping>
+	<mapping>
+		<identity value="loinc" />
+		<uri value="http://loinc.org" />
+		<name value="LOINC" />
+	</mapping>
+	<kind value="resource" />
+	<constrainedType value="Patient" />
+	<abstract value="false" />
+	<base value="http://example.com/fhir/SD/patient-identifier-subslice" />
+	<snapshot>
+		<element>
+			<path value="Patient" />
+			<short value="Information about an individual or animal receiving health care services" />
+			<definition value="Demographics and other administrative information about an individual or animal receiving care or other health-related services." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="DomainResource" />
+			</type>
+			<constraint>
+				<key value="dom-2" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+				<xpath value="not(parent::f:contained and f:contained)" />
+			</constraint>
+			<constraint>
+				<key value="dom-1" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL NOT contain any narrative" />
+				<xpath value="not(parent::f:contained and f:text)" />
+			</constraint>
+			<constraint>
+				<key value="dom-4" />
+				<severity value="error" />
+				<human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+				<xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+			</constraint>
+			<constraint>
+				<key value="dom-3" />
+				<severity value="error" />
+				<human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource" />
+				<xpath value="not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat(&#39;#&#39;, $id))]))" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Patient[classCode=PAT]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="ClinicalDocument.recordTarget.patientRole" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="administrative.individual" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.id" />
+			<short value="Logical id of this artifact" />
+			<definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+			<comments value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.meta" />
+			<short value="Metadata about the resource" />
+			<definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.meta" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.implicitRules" />
+			<short value="A set of rules under which this content was created" />
+			<definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content." />
+			<comments value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.implicitRules" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.language" />
+			<short value="Language of the resource content" />
+			<definition value="The base language in which the resource is written." />
+			<comments value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Resource.language" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.text" />
+			<short value="Text summary of the resource, for human interpretation" />
+			<definition value="A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+			<comments value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative." />
+			<alias value="narrative" />
+			<alias value="html" />
+			<alias value="xhtml" />
+			<alias value="display" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="DomainResource.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Narrative" />
+			</type>
+			<condition value="dom-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="Act.text?" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contained" />
+			<short value="Contained, inline Resources" />
+			<definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+			<comments value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again." />
+			<alias value="inline resources" />
+			<alias value="anonymous resources" />
+			<alias value="contained resources" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.contained" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Resource" />
+			</type>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Entity. Role, or Act" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="doNotCall" />
+			<short value="Do not call flag." />
+			<definition value="A flag indicating that a patient has requested their contact information be added to the do-not-call list." />
+			<comments value="Comments for do not call flag root element." />
+			<requirements value="Requirements for do not call flag root element." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="doNotCall.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="doNotCall.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="doNotCall.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="legalCase" />
+			<label value="Legal Case Flag" />
+			<short value="Base for all elements" />
+			<definition value="A flag indicating that a patient is involved in a legal dispute with the enterprise." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="legalCase.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="legalCase.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x].extension" />
+			<name value="legalCase.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean" />
+			<name value="legalCase.valueBoolean" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel" />
+			<label value="Lead Counsel" />
+			<short value="Base for all elements" />
+			<definition value="Identification of the the legal counsel assigned to the case in question." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.extension" />
+			<name value="legalCase.valueBoolean.leadCounsel.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.leadCounsel.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.extension.value[x]" />
+			<name value="legalCase.valueBoolean.leadCounsel.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.valueBoolean.value" />
+			<representation value="xmlAttr" />
+			<name value="legalCase.valueBoolean.value" />
+			<short value="Primitive value for boolean" />
+			<definition value="Primitive value for boolean" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="boolean.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="religion" />
+			<label value="Patient Religion" />
+			<short value="Patient&#39;s professed religious affiliation" />
+			<definition value="A code classifying a person&#39;s professed religion." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="religion.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="religion.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="0" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="religion.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="religion.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="A code classifying a person&#39;s professed religion" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<slicing>
+				<discriminator value="type.value[x]" />
+				<rules value="open" />
+			</slicing>
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth/grandfatheredResAuth" />
+			<short value="Base for all elements" />
+			<definition value="Record of the patients general research authorization status." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.type" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.type.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.type.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.type.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="type" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.type.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="grandfathered" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.flag" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.flag.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.flag.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.flag.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="flag" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.flag.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.date" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.date.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.extension" />
+			<name value="researchAuth/grandfatheredResAuth.date.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.date.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="date" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.date.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="researchAuth/grandfatheredResAuth.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="DomainResource.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="2" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn" />
+			<label value="Medical Record Number" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mrn.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mrn.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mrn.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn.issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="Extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mrn.issuingSite.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mrn.issuingSite.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].extension" />
+			<name value="mrn.issuingSite.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept" />
+			<name value="mrn.issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn.issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.extension" />
+			<name value="mrn.issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mrn/officialMRN" />
+			<label value="Medical Record Number" />
+			<short value="A medical record number." />
+			<definition value="A technical identifier - identifies some entity uniquely and unambiguously." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mrn/officialMRN.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mrn/officialMRN.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mrn/officialMRN.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mrn/officialMRN.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mrn/officialMRN.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MRN" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mrn/officialMRN.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mrn/officialMRN.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mrn/officialMRN.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier" />
+			<name value="mdmId" />
+			<label value="Master Patient Id" />
+			<short value="An identifier for this patient" />
+			<definition value="An identifier for this patient." />
+			<requirements value="Patients are almost always assigned specific numerical identifiers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.identifier" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Identifier" />
+				<profile value="http://example.com/fhir/SD/patient-mdm-id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Identifier" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".id" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="id" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.extension.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.extension.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.extension.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension" />
+			<name value="mdmId.issuingSite" />
+			<short value="Site code where an identifier was issued." />
+			<definition value="Optional Extensions Element - found in all resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+				<profile value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.extension" />
+			<name value="mdmId.issuingSite.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.url" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.url" />
+			<short value="identifies the meaning of the extension" />
+			<definition value="Source of the definition for the extension code - a logical name or a URL." />
+			<comments value="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.url" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/StructureDefinition/patient-identifier-issuing-site" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x]" />
+			<name value="mdmId.issuingSite.value[x]" />
+			<short value="Value of extension" />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<type>
+				<code value="decimal" />
+			</type>
+			<type>
+				<code value="base64Binary" />
+			</type>
+			<type>
+				<code value="instant" />
+			</type>
+			<type>
+				<code value="string" />
+			</type>
+			<type>
+				<code value="uri" />
+			</type>
+			<type>
+				<code value="date" />
+			</type>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<type>
+				<code value="time" />
+			</type>
+			<type>
+				<code value="code" />
+			</type>
+			<type>
+				<code value="oid" />
+			</type>
+			<type>
+				<code value="id" />
+			</type>
+			<type>
+				<code value="unsignedInt" />
+			</type>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<type>
+				<code value="markdown" />
+			</type>
+			<type>
+				<code value="Annotation" />
+			</type>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<type>
+				<code value="Identifier" />
+			</type>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<type>
+				<code value="Coding" />
+			</type>
+			<type>
+				<code value="Quantity" />
+			</type>
+			<type>
+				<code value="Range" />
+			</type>
+			<type>
+				<code value="Period" />
+			</type>
+			<type>
+				<code value="Ratio" />
+			</type>
+			<type>
+				<code value="SampledData" />
+			</type>
+			<type>
+				<code value="Signature" />
+			</type>
+			<type>
+				<code value="Reference" />
+			</type>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<type>
+				<code value="Address" />
+			</type>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<type>
+				<code value="Timing" />
+			</type>
+			<type>
+				<code value="Meta" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.value[x].id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.value[x].extension" />
+			<name value="mdmId.issuingSite.value[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept" />
+			<name value="mdmId.issuingSite.valueCodeableConcept" />
+			<short value="The is the codeable." />
+			<definition value="Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list)." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Extension.value[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<valueSetUri value="http://example.com/fhir/localsystems/patient-id-site" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.id" />
+			<representation value="xmlAttr" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.extension.valueCodeableConcept.extension" />
+			<name value="mdmId.issuingSite.valueCodeableConcept.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.use" />
+			<name value="mdmId.use" />
+			<short value="usual | official | temp | secondary (If known)" />
+			<definition value="The purpose of this identifier." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary id for a permanent one. Applications can assume that an identifier is permanent unless it explicitly says that it is temporary." />
+			<requirements value="Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Identifies the purpose for this identifier, if known ." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.type" />
+			<name value="mdmId.type" />
+			<short value="Description of identifier" />
+			<definition value="A coded type for the identifier that can be used to determine which identifier to use for a specific purpose." />
+			<comments value="This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage. 
+      Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type." />
+			<requirements value="Allows users to make use of identifiers when the identifier system is not known." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.type" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="A coded type for an identifier that can be used to determine which identifier to use for a specific purpose." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/identifier-type" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.code or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.system" />
+			<name value="mdmId.system" />
+			<short value="The namespace for the identifier" />
+			<definition value="Establishes the namespace in which set of possible id values is unique." />
+			<comments value="see http://en.wikipedia.org/wiki/Uniform_resource_identifier" />
+			<requirements value="There are many sequences of identifiers.  To perform matching, we need to know what sequence we&#39;re dealing with. The system identifies a particular sequence or set of unique identifiers." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://example.com/fhir/localsystems/PATIENT-ID-MDM" />
+			<exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / EI-2-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.root or Role.id.root" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.value" />
+			<name value="mdmId.value" />
+			<short value="The value that is unique" />
+			<definition value="The portion of the identifier typically displayed to the user and which is unique within the context of the system." />
+			<comments value="If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<exampleString value="123456" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.1 / EI.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.period" />
+			<name value="mdmId.period" />
+			<short value="Time period when id is/was valid for use" />
+			<definition value="Time period during which identifier is/was valid for use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.7 + CX.8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="Role.effectiveTime or implied by context" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.identifier.assigner" />
+			<name value="mdmId.assigner" />
+			<short value="Organization that issued id (may be just text)" />
+			<definition value="Organization that issued/manages the identifier." />
+			<comments value="The reference may be just a text description of the assigner." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Identifier.assigner" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="CX.4 / (CX.4,CX.9,CX.10)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./IdentifierIssuingAuthority" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.active" />
+			<short value="Whether this patient&#39;s record is in active use" />
+			<definition value="Whether this patient record is in active use." />
+			<comments value="Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient." />
+			<requirements value="Need to be able to mark a patient record as not to be used because it was created in error." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.active" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<defaultValueBoolean value="true" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="statusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="w5" />
+				<map value="status" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes." />
+			<comments value="The gender may not match the biological sex as determined by genetics, or the individual&#39;s preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a &quot;hard&quot; error." />
+			<requirements value="Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.administrativeGenderCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.birthDate" />
+			<short value="The date of birth for the individual" />
+			<definition value="The date of birth for the individual." />
+			<comments value="At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension &quot;patient-birthTime&quot; available that should be used where Time is required (such as in maternaty/infant care systems)." />
+			<requirements value="Age of the individual drives many clinical processes." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.birthDate" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="date" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-7" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.birthTime" />
+			</mapping>
+			<mapping>
+				<identity value="loinc" />
+				<map value="21112-8" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x]" />
+			<short value="Indicates if the individual is deceased or not" />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceased[x].extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime" />
+			<short value="A type slice of deceased[x] for dateTime using element naming only." />
+			<definition value="Indicates if the individual is deceased or not." />
+			<comments value="If there&#39;s no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive." />
+			<requirements value="The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.deceased[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="dateTime" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-30  (bool) and PID-29 (datetime)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.deceasedDateTime.value" />
+			<representation value="xmlAttr" />
+			<short value="Primitive value for dateTime" />
+			<definition value="Primitive value for dateTime" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="dateTime.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+		</element>
+		<element>
+			<path value="Patient.address" />
+			<short value="Addresses for the individual" />
+			<definition value="Addresses for the individual." />
+			<comments value="Patient may have multiple addresses with different uses or applicable periods." />
+			<requirements value="May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.address" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".addr" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.maritalStatus" />
+			<short value="Marital (civil) status of a patient" />
+			<definition value="This field contains a patient&#39;s most recent marital (civil) status." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Most, if not all systems capture it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.maritalStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The domestic partnership status of a person." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/marital-status" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-16" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN]/maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.maritalStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.multipleBirth[x]" />
+			<short value="Whether patient is part of a multiple birth" />
+			<definition value="Indicates whether the patient is part of a multiple or indicates the actual birth order." />
+			<comments value="Where the valueInteger is provided, the number is the birth number in the sequence.
+      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3
+      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated)." />
+			<requirements value="For disambiguation of multiple-birth children, especially relevant where the care provider doesn&#39;t meet the patient, such as labs." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.multipleBirth[x]" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<type>
+				<code value="integer" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-24 (bool), PID-25 (integer)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.photo" />
+			<short value="Image of the patient" />
+			<definition value="Image of the patient." />
+			<comments value="When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as &quot;Attachment&quot;." />
+			<requirements value="Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.photo" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Attachment" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="att-1" />
+				<severity value="error" />
+				<human value="It the Attachment has data, it SHALL have a contentType" />
+				<xpath value="not(exists(f:data)) or exists(f:contentType)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="OBX-5 - needs a profile" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="ED/RP" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="ED" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Contact" />
+			</extension>
+			<path value="Patient.contact" />
+			<short value="A contact party (e.g. guardian, partner, friend) for the patient" />
+			<definition value="A contact party (e.g. guardian, partner, friend) for the patient." />
+			<comments value="Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact." />
+			<requirements value="Need to track people you can contact about the patient." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="pat-1" />
+				<severity value="error" />
+				<human value="SHALL at least contain a contact&#39;s details or a reference to an organization" />
+				<xpath value="f:name or f:telecom or f:address or f:organization" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.relationship" />
+			<short value="The kind of relationship" />
+			<definition value="The nature of the relationship between the patient and the contact person." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Used to determine which contact person is the most relevant to approach, depending on circumstances." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.relationship" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="extensible" />
+				<description value="The nature of the relationship between a patient and a contact person for that patient." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/patient-contact-relationship" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-7, NK1-3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.name" />
+			<short value="A name associated with the contact person" />
+			<definition value="A name associated with the contact person." />
+			<comments value="Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely." />
+			<requirements value="Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.name" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.telecom" />
+			<short value="A contact detail for the person" />
+			<definition value="A contact detail for the person, e.g. a telephone number or an email address." />
+			<comments value="Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.contact.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-5, NK1-6, NK1-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.address" />
+			<short value="Address for the contact person" />
+			<definition value="Address for the contact person." />
+			<comments value="Note: address is for postal addresses, not physical locations." />
+			<requirements value="Need to keep track where the contact person can be contacted per postal mail or visited." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.address" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Address" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="addr" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XAD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="AD" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="Address" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.gender" />
+			<short value="male | female | other | unknown" />
+			<definition value="Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<requirements value="Needed to address the person correctly." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.gender" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<binding>
+				<strength value="required" />
+				<description value="The gender of a person used for administrative purposes." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/administrative-gender" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.organization" />
+			<short value="Organization that is associated with the contact" />
+			<definition value="Organization on behalf of which the contact is acting or for which the contact is working." />
+			<requirements value="For guardians or business related contacts, the organization is relevant." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.organization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="pat-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="NK1-13, NK1-30, NK1-31, NK1-32, NK1-41" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.contact.period" />
+			<short value="The period during which this contact person or organization is valid to be contacted relating to this patient" />
+			<definition value="The period during which this contact person or organization is valid to be contacted relating to this patient." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.contact.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="effectiveTime" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="Animal" />
+			</extension>
+			<path value="Patient.animal" />
+			<short value="This patient is known to be an animal (non-human)" />
+			<definition value="This patient is known to be an animal." />
+			<comments value="The animal element is labeled &quot;Is Modifier&quot; since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal)." />
+			<requirements value="Many clinical systems are extended to care for animal patients as well as human." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=ANM]" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.species" />
+			<short value="E.g. Dog, Cow" />
+			<definition value="Identifies the high level taxonomic categorization of the kind of animal." />
+			<comments value="If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word &quot;Hereford&quot; does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for &quot;Hereford Cattle Breed&quot; does.)." />
+			<requirements value="Need to know what kind of animal." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.species" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The species of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-species" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-35" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.breed" />
+			<short value="E.g. Poodle, Angus" />
+			<definition value="Identifies the detailed categorization of the kind of animal." />
+			<comments value="Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type." />
+			<requirements value="May need to know the specific kind within the species." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.breed" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The breed of an animal." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-breeds" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-37" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.animal.genderStatus" />
+			<short value="E.g. Neutered, Intact" />
+			<definition value="Indicates the current state of the animal&#39;s reproductive organs." />
+			<comments value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+			<requirements value="Gender status can affect housing and animal behavior." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.animal.genderStatus" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="example" />
+				<description value="The state of the animal&#39;s reproductive organs." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/animal-genderstatus" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="genderStatusCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication" />
+			<short value="A list of Languages which may be used to communicate with the patient about his or her health" />
+			<definition value="Languages which may be used to communicate with the patient about his or her health." />
+			<comments value="If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required." />
+			<requirements value="If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.communication" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="LanguageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="patient.languageCommunication" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.language" />
+			<short value="The language which can be used to communicate with the patient about his or her health" />
+			<definition value="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." />
+			<comments value="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." />
+			<requirements value="Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.language" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="A human language." />
+				<valueSetUri value="http://tools.ietf.org/html/bcp47" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15, LAN-2" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".languageCode" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="CE/CNE/CWE" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="CD" />
+			</mapping>
+			<mapping>
+				<identity value="orim" />
+				<map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.communication.preferred" />
+			<short value="Language preference indicator" />
+			<definition value="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." />
+			<comments value="This language is specifically identified for communicating healthcare information." />
+			<requirements value="People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.communication.preferred" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="boolean" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-15" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".preferenceInd" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Patient&#39;s nominated primary care provider" />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare" />
+			<slicing>
+				<discriminator value="@profile" />
+				<rules value="open" />
+			</slicing>
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="organizationCare/teamCare" />
+			<short value="Care providers that are organizations." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://example.com/fhir/SD/organization-team" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="organizationCare/teamCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="organizationCare/teamCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="organizationCare/teamCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="organizationCare/teamCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider" />
+			<name value="practitionerCare" />
+			<short value="Care providers that are practitioners." />
+			<definition value="Patient&#39;s nominated care provider." />
+			<comments value="This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.
+      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.careProvider" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PD1-4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="subjectOf.CareEvent.performer.AssignedEntity" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.id" />
+			<representation value="xmlAttr" />
+			<name value="practitionerCare.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.extension" />
+			<name value="practitionerCare.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.reference" />
+			<name value="practitionerCare.reference" />
+			<short value="Relative, internal or absolute URL reference" />
+			<definition value="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with &#39;#&#39;) refer to contained resources." />
+			<comments value="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.reference" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ref-1" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.careProvider.display" />
+			<name value="practitionerCare.display" />
+			<short value="Text alternative for the resource" />
+			<definition value="Plain text narrative that identifies the resource in addition to the resource reference." />
+			<comments value="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what&#39;s being referenced, not to fully describe it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Reference.display" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.managingOrganization" />
+			<short value="Organization that is the custodian of the patient record" />
+			<definition value="Organization that is the custodian of the patient record." />
+			<comments value="There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association)." />
+			<requirements value="Need to know who recognizes this patient record, manages and updates it." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.managingOrganization" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="scoper" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".providerOrganization" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link" />
+			<short value="Link to another patient resource that concerns the same actual person" />
+			<definition value="Link to another patient resource that concerns the same actual patient." />
+			<comments value="There is no assumption that linked patient records have mutual links." />
+			<requirements value="There are multiple usecases: 
+      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple servers." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.link" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="BackboneElement" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="outboundLink" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.modifierExtension" />
+			<short value="Extensions that cannot be ignored" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<alias value="modifiers" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="BackboneElement.modifierExtension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.other" />
+			<short value="The other patient resource that the link refers to" />
+			<definition value="The other patient resource that the link refers to." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.other" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Reference" />
+				<profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ref-1" />
+				<severity value="error" />
+				<human value="SHALL have a local reference if the resource is provided inline" />
+				<xpath value="not(starts-with(f:reference/@value, &#39;#&#39;)) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, &#39;#&#39;)])" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-3, MRG-1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="id" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.link.type" />
+			<short value="replace | refer | seealso - type of link" />
+			<definition value="The type of link between this patient resource and another patient resource." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="Patient.link.type" />
+				<min value="1" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The type of link between this patient resource and another patient resource." />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/link-type" />
+			</binding>
+			<mapping>
+				<identity value="rim" />
+				<map value="typeCode" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+	</snapshot>
+	<differential>
+		<element>
+			<path value="Patient.extension" />
+			<name value="researchAuth" />
+			<slicing>
+				<discriminator value="type.value[x]" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="Patient.extension.extension.value[x]" />
+			<name value="researchAuth/grandfatheredResAuth.type.value[x]" />
+			<fixedCode value="grandfathered" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-telecom-reslice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-telecom-reslice-profile.xml
@@ -1,8 +1,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-telecom-reslice" />
+	<name value="patient-telecom-reslice" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -32,7 +31,7 @@
 	<kind value="resource" />
 	<constrainedType value="Patient" />
 	<abstract value="false" />
-	<base value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<base value="http://example.com/fhir/SD/patient-name-slice" />
 	<snapshot>
 		<element>
 			<path value="Patient" />
@@ -3086,6 +3085,10 @@
 		</element>
 		<element>
 			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A name associated with the patient" />
 			<definition value="A name associated with the individual." />
 			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
@@ -3138,7 +3141,1236 @@
 			</mapping>
 		</element>
 		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
 			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
 			<short value="A contact detail for the individual" />
 			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
 			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
@@ -3190,6 +4422,2834 @@
 			<mapping>
 				<identity value="servd" />
 				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="phone" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="Phone numbers." />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="phone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="phone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="phone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="phone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="phone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="phone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="phone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="phone/homePhone" />
+			<short value="Phone numbers." />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="phone/homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="phone/homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="phone/homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="phone/homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="phone/homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="phone/homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="phone/homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="phone/mobilePhone" />
+			<short value="Phone numbers." />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="phone/mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="phone/mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="phone/mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="phone/mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="phone/mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="phone/mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="phone/mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="email" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="email.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="email.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="email.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="email.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="email.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="email.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="email.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="email/workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="email/workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="email/workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="email/workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="email/workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="email/workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="email/workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="email/workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="email/homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="email/homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="email/homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="email/homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="email/homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="email/homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="email/homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="email/homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -4992,54 +9052,70 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<rules value="open" />
+			</slicing>
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
+			<path value="Patient.telecom" />
+			<name value="phone" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+			<short value="Phone numbers." />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
+			<path value="Patient.telecom.system" />
+			<name value="phone.system" />
+			<min value="1" />
+			<fixedCode value="phone" />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
+			<path value="Patient.telecom.use" />
+			<name value="phone/homePhone.use" />
+			<min value="1" />
+			<fixedCode value="home" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
+			<path value="Patient.telecom.use" />
+			<name value="phone/mobilePhone.use" />
+			<min value="1" />
+			<fixedCode value="mobile" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			</type>
+			<path value="Patient.telecom" />
+			<name value="email" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="email.system" />
+			<min value="1" />
+			<fixedCode value="email" />
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="email/workEmail.use" />
+			<min value="1" />
+			<fixedCode value="work" />
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="email/homeEmail.use" />
+			<min value="1" />
+			<fixedCode value="home" />
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<min value="1" />
+			<fixedCode value="pager" />
 		</element>
 	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-telecom-slice-profile.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Chris Grenz/patient-telecom-slice-profile.xml
@@ -1,8 +1,8 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<url value="http://example.com/fhir/SD/patient-with-extensions" />
-	<name value="patient-extensions" />
+	<url value="http://example.com/fhir/SD/patient-telecom-slice" />
+	<name value="patient-telecom-slice" />
 	<status value="draft" />
-	<description value="An example profile where extensions are applied: extension is sliced and each named slice uses type.profile to indicate how the extesion should described/constrained." />
+	<description value="Slice Patient.telecom by multiple discriminators." />
 	<fhirVersion value="1.0.2" />
 	<mapping>
 		<identity value="rim" />
@@ -32,7 +32,7 @@
 	<kind value="resource" />
 	<constrainedType value="Patient" />
 	<abstract value="false" />
-	<base value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<base value="http://example.com/fhir/SD/patient-name-slice" />
 	<snapshot>
 		<element>
 			<path value="Patient" />
@@ -3086,6 +3086,10 @@
 		</element>
 		<element>
 			<path value="Patient.name" />
+			<slicing>
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A name associated with the patient" />
 			<definition value="A name associated with the individual." />
 			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
@@ -3138,7 +3142,1237 @@
 			</mapping>
 		</element>
 		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<alias value="surname" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="officialName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="officialName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="officialName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="officialName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="official" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="officialName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="officialName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="officialName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="officialName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="officialName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="officialName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name" />
+			<name value="maidenName" />
+			<short value="A name associated with the patient" />
+			<definition value="A name associated with the individual." />
+			<comments value="A patient may have multiple names with different uses or applicable periods. For animals, the name is a &quot;HumanName&quot; in the sense that is assigned and used by humans and has the same patterns." />
+			<requirements value="Need to be able to track the patient by multiple names. Examples are your official name and a partner name." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.name" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="HumanName" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-5, PID-9" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="name" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".patient.name" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="EN (actually, PN)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ProviderName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.id" />
+			<representation value="xmlAttr" />
+			<name value="maidenName.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.extension" />
+			<name value="maidenName.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.use" />
+			<name value="maidenName.use" />
+			<short value="usual | official | temp | nickname | anonymous | old | maiden" />
+			<definition value="Identifies the purpose for this name." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Allows the appropriate name for a particular context of use to be selected from among a set of names." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="maiden" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="The use of a human name" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/name-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.7, but often indicated by which field contains the name" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./NamePurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.text" />
+			<name value="maidenName.text" />
+			<short value="Text representation of the full name" />
+			<definition value="A full text representation of the name." />
+			<comments value="Can provide both a text representation and structured parts." />
+			<requirements value="A renderable, unencoded form." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.text" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="implied by XPN.11" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./formatted" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.family" />
+			<name value="maidenName.family" />
+			<short value="Family name (often called &#39;Surname&#39;)" />
+			<definition value="The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father." />
+			<comments value="For family name, hyphenated names such as &quot;Smith-Jones&quot; are a single name, but names with spaces such as &quot;Smith Jones&quot; are broken into multiple parts." />
+			<min value="1" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.family" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.1" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = FAM]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./FamilyName" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.given" />
+			<name value="maidenName.given" />
+			<short value="Given names (not always &#39;first&#39;). Includes middle names" />
+			<definition value="Given name." />
+			<comments value="If only initials are recorded, they may be used in place of the full name.  Not called &quot;first name&quot; since given names do not always come first." />
+			<alias value="first name" />
+			<alias value="middle name" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.given" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.2 + XPN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = GIV]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./GivenNames" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.prefix" />
+			<name value="maidenName.prefix" />
+			<short value="Parts that come before the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.prefix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.5" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = PFX]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./TitleCode" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.suffix" />
+			<name value="maidenName.suffix" />
+			<short value="Parts that come after the name" />
+			<definition value="Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="HumanName.suffix" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN/4" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./part[partType = SFX]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.name.period" />
+			<name value="maidenName.period" />
+			<short value="Time period when name was/is in use" />
+			<definition value="Indicates the period of time when this name was valid for the named person." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<requirements value="Allows names to be placed in historical context." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="HumanName.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XPN.13 + XPN.14" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./usablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
 			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 			<short value="A contact detail for the individual" />
 			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
 			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
@@ -3190,6 +4424,2108 @@
 			<mapping>
 				<identity value="servd" />
 				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="mobilePhone" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="mobilePhone.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="mobilePhone.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="phone" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="mobilePhone.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mobile" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="mobilePhone.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="mobilePhone.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="homeEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="homeEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="homeEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="homeEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="home" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="homeEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="homeEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="workEmail" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner&#39;s phone)." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="workEmail.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="workEmail.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="email" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="workEmail.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="work" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="workEmail.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="workEmail.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<short value="A contact detail for the individual" />
+			<definition value="A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted." />
+			<comments value="Only one of the two discriminators fixed." />
+			<requirements value="People have (primary) ways to contact them in some way such as phone, email." />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Patient.telecom" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="ContactPoint" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="cpt-2" />
+				<severity value="error" />
+				<human value="A system is required if a value is provided." />
+				<xpath value="not(exists(f:value)) or exists(f:system)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="PID-13, PID-14, PID-40" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="telecom" />
+			</mapping>
+			<mapping>
+				<identity value="cda" />
+				<map value=".telecom" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="TEL" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="ContactPoint" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.id" />
+			<representation value="xmlAttr" />
+			<name value="pager.id" />
+			<short value="xml:id (or equivalent in JSON)" />
+			<definition value="unique id for the element within a resource (for internal references)." />
+			<comments value="RFC 4122" />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="Element.id" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="id" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.extension" />
+			<name value="pager.extension" />
+			<short value="Additional Content defined by implementations" />
+			<definition value="May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+			<comments value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+			<alias value="extensions" />
+			<alias value="user content" />
+			<min value="0" />
+			<max value="*" />
+			<base>
+				<path value="Element.extension" />
+				<min value="0" />
+				<max value="*" />
+			</base>
+			<type>
+				<code value="Extension" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<short value="phone | fax | email | pager | other" />
+			<definition value="Telecommunications form for contact point - what communications system is required to make use of the contact." />
+			<comments value="Note that FHIR strings may not exceed 1MB in size" />
+			<min value="1" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.system" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="pager" />
+			<condition value="cpt-2" />
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Telecommunications form for contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-system" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.3" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./scheme" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointType" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.value" />
+			<name value="pager.value" />
+			<short value="The actual contact point details" />
+			<definition value="The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address)." />
+			<comments value="Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value." />
+			<requirements value="Need to support legacy numbers that are not in a tightly controlled format." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.value" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="string" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.1 (or XTN.12)" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./url" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./Value" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="pager.use" />
+			<short value="home | work | temp | old | mobile - purpose of this contact point" />
+			<definition value="Identifies the purpose for the contact point." />
+			<comments value="This is labeled as &quot;Is Modifier&quot; because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old." />
+			<requirements value="Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.use" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="code" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isModifier value="true" />
+			<isSummary value="true" />
+			<binding>
+				<strength value="required" />
+				<description value="Use of contact point" />
+				<valueSetUri value="http://hl7.org/fhir/ValueSet/contact-point-use" />
+			</binding>
+			<mapping>
+				<identity value="v2" />
+				<map value="XTN.2 - but often indicated by field" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="unique(./use)" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./ContactPointPurpose" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.rank" />
+			<name value="pager.rank" />
+			<short value="Specify preferred order of use (1 = highest)" />
+			<definition value="Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values." />
+			<comments value="Note that rank does not necessarily follow the order in which the contacts are represented in the instance." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.rank" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="positiveInt" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="n/a" />
+			</mapping>
+		</element>
+		<element>
+			<path value="Patient.telecom.period" />
+			<name value="pager.period" />
+			<short value="Time period when the contact point was/is in use" />
+			<definition value="Time period when the contact point was/is in use." />
+			<comments value="This is not a duration - that&#39;s a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. &quot;the patient was an inpatient of the hospital for this time range&quot;) or one value from the range applies (e.g. &quot;give to the patient between these two times&quot;). If duration is required, specify the type as Interval|Duration." />
+			<min value="0" />
+			<max value="1" />
+			<base>
+				<path value="ContactPoint.period" />
+				<min value="0" />
+				<max value="1" />
+			</base>
+			<type>
+				<code value="Period" />
+			</type>
+			<condition value="ele-1" />
+			<constraint>
+				<key value="per-1" />
+				<severity value="error" />
+				<human value="If present, start SHALL have a lower value than end" />
+				<xpath value="not(exists(f:start)) or not(exists(f:end)) or (f:start/@value &lt;= f:end/@value)" />
+			</constraint>
+			<constraint>
+				<key value="ele-1" />
+				<severity value="error" />
+				<human value="All FHIR elements must have a @value or children" />
+				<xpath value="@value|f:*|h:div" />
+			</constraint>
+			<isSummary value="true" />
+			<mapping>
+				<identity value="v2" />
+				<map value="N/A" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="./useablePeriod[type=&quot;IVL&lt;TS&gt;&quot;]" />
+			</mapping>
+			<mapping>
+				<identity value="servd" />
+				<map value="./StartDate and ./EndDate" />
+			</mapping>
+			<mapping>
+				<identity value="v2" />
+				<map value="DR" />
+			</mapping>
+			<mapping>
+				<identity value="rim" />
+				<map value="IVL&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;] or URG&lt;TS&gt;[lowClosed=&quot;true&quot; and highClosed=&quot;true&quot;]" />
 			</mapping>
 			<mapping>
 				<identity value="rim" />
@@ -4992,54 +8328,71 @@
 	</snapshot>
 	<differential>
 		<element>
-			<path value="Patient.extension" />
-			<name value="doNotCall" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-do-not-call" />
-			</type>
+			<path value="Patient.telecom" />
+			<slicing>
+				<discriminator value="system" />
+				<discriminator value="use" />
+				<rules value="open" />
+			</slicing>
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="legalCase" />
-			<label value="Legal Case Flag" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case" />
-			</type>
+			<path value="Patient.telecom.system" />
+			<name value="homePhone.system" />
+			<min value="1" />
+			<fixedCode value="phone" />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean" />
-			<name value="legalCase.valueBoolean" />
-			<type>
-				<code value="boolean" />
-			</type>
+			<path value="Patient.telecom.use" />
+			<name value="homePhone.use" />
+			<min value="1" />
+			<fixedCode value="home" />
 		</element>
 		<element>
-			<path value="Patient.extension.valueBoolean.extension" />
-			<name value="legalCase.valueBoolean.leadCounsel" />
-			<label value="Lead Counsel" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel" />
-			</type>
+			<path value="Patient.telecom.system" />
+			<name value="mobilePhone.system" />
+			<min value="1" />
+			<fixedCode value="phone" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="religion" />
-			<label value="Patient Religion" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://hl7.org/fhir/StructureDefinition/us-core-religion" />
-			</type>
+			<path value="Patient.telecom.use" />
+			<name value="mobilePhone.use" />
+			<min value="1" />
+			<fixedCode value="mobile" />
 		</element>
 		<element>
-			<path value="Patient.extension" />
-			<name value="researchAuth" />
-			<type>
-				<code value="Extension" />
-				<profile value="http://example.com/fhir/StructureDefinition/patient-research-authorization" />
-			</type>
+			<path value="Patient.telecom.system" />
+			<name value="homeEmail.system" />
+			<min value="1" />
+			<fixedCode value="email" />
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="homeEmail.use" />
+			<min value="1" />
+			<fixedCode value="home" />
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="workEmail.system" />
+			<min value="1" />
+			<fixedCode value="email" />
+		</element>
+		<element>
+			<path value="Patient.telecom.use" />
+			<name value="workEmail.use" />
+			<min value="1" />
+			<fixedCode value="work" />
+		</element>
+		<element>
+			<path value="Patient.telecom" />
+			<name value="pager" />
+			<comments value="Only one of the two discriminators fixed." />
+		</element>
+		<element>
+			<path value="Patient.telecom.system" />
+			<name value="pager.system" />
+			<min value="1" />
+			<fixedCode value="pager" />
 		</element>
 	</differential>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyExtension1.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyExtension1.structuredefinition.xml
@@ -21,7 +21,6 @@
     </element>
     <element>
       <path value="Extension.url" />
-      <representation value="xmlAttr" />
       <fixedUri value="http://example.org/fhir/StructureDefinition/MyExtension1" />
     </element>
     <element>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyExtension2.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MyExtension2.structuredefinition.xml
@@ -21,7 +21,6 @@
     </element>
     <element>
       <path value="Extension.url" />
-      <representation value="xmlAttr" />
       <fixedUri value="http://example.org/fhir/StructureDefinition/MyExtension2" />
     </element>
     <element>

--- a/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.Net40.csproj
+++ b/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.Net40.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Specification\Snapshot\ElementDefnMerger.cs" />
     <Compile Include="Specification\Snapshot\ElementMatcher.cs" />
     <Compile Include="Specification\Snapshot\SnapshotElementBaseGenerator.cs" />
+    <Compile Include="Specification\Snapshot\SnapshotElementIdGenerator.cs" />
     <Compile Include="Specification\Snapshot\SnapshotGenerator.cs" />
     <Compile Include="Specification\Snapshot\SnapshotGeneratorEvents.cs" />
     <Compile Include="Specification\Snapshot\SnapshotGeneratorExtensions.cs" />

--- a/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.Net45.csproj
+++ b/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.Net45.csproj
@@ -76,6 +76,7 @@
       <Link>Support\StringExtensions.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyVersionInfo.cs" />
+    <Compile Include="Specification\Snapshot\SnapshotElementIdGenerator.cs" />
     <Compile Include="Specification\Source\CachedResolver.cs" />
     <Compile Include="Specification\Source\IConformanceSource.cs" />
     <Compile Include="Specification\Source\MultiResolver.cs" />

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/ElementDefinitionNavigator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/ElementDefinitionNavigator.cs
@@ -632,6 +632,13 @@ namespace Hl7.Fhir.Specification.Navigation
             return count;
         }
 
+        // [WMR 20160917] New
+        public static string GetLastPathComponent(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return string.Empty;
+            var pos = path.LastIndexOf(".");
+            return pos > -1 ? path.Substring(pos + 1) : path;
+        }
 
         public override string ToString()
         {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -40,6 +40,10 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             private void merge(ElementDefinition snap, ElementDefinition diff)
             {
+                // [WMR 20160915] Important! Derived profiles should never inherit the ChangedByDiff extension
+                // Caller should make sure that existing extensions have been removed from snap,
+                // otherwise associated diff elems will be considered as changed (because they don't have the extension yet).
+
                 // bool isExtensionConstraint = snap.Path == "Extension" || snap.IsExtension();
 
                 // paths can be changed under one circumstance: the snap is a choice[x] element, and diff limits the type choices
@@ -232,7 +236,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                     // [WMR 20160915] Never inherit Changed extension from base profile!
                     // Remove before comparing
-                    result.RemoveAllChangedByDiff();
+                    // result.RemoveAllChangedByDiff();
 
                     // Just add new elements to the result, never replace existing ones
                     foreach (var element in diff)

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -129,6 +129,8 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // TODO: [GG] what to do about conditions?  [EK] We have key, so merge Constraint and condition based on that?
                 // Constraints are cumulative, so they are always "new" (hence a constant false for the comparer)
+                // [WMR 20160917] Note: constraint keys must be unique. The validator will detect duplicate keys, so the derived
+                // profile author can correct the conflicting constraint key.
                 snap.Constraint = mergeCollection(snap.Constraint, diff.Constraint, (a, b) => false);
 
                 // [WMR 20160907] merge conditions

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -222,11 +222,17 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             private List<T> mergeCollection<T>(List<T> snap, List<T> diff, Func<T, T, bool> elemComparer) where T : Element
             {
-                //TODO: The next != null should be IsNullOrEmpty(), but we don't have that yet for complex types
-                // if (diff != null && !diff.IsExactly(snap))
+                // [WMR 20160915] Handle ChangedByDiff extension
+                // - Should not affect equality testing
+                // - Should not be inherited by derived profiles
+                
                 if (!diff.IsNullOrEmpty() && !diff.IsExactly(snap))
                 {
                     var result = snap == null ? new List<T>() : new List<T>((IEnumerable<T>)snap.DeepCopy());
+
+                    // [WMR 20160915] Never inherit Changed extension from base profile!
+                    // Remove before comparing
+                    result.RemoveAllChangedByDiff();
 
                     // Just add new elements to the result, never replace existing ones
                     foreach (var element in diff)

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotElementIdGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotElementIdGenerator.cs
@@ -1,0 +1,86 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using Hl7.Fhir.Support;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Snapshot
+{
+    // [WMR 20160917] NEW
+    // Methods to generate ElementId values
+
+    public partial class SnapshotGenerator
+    {
+        public void GenerateSnapshotElementsId(StructureDefinition structureDef, bool force = false)
+        {
+            if (structureDef == null) { throw Error.ArgumentNull("structureDef"); }
+            if (!structureDef.HasSnapshot) { throw Error.Argument("structureDef", "StructureDefinition.Snapshot component is null or empty."); }
+            clearIssues();
+            generateSnapshotElementsId(structureDef, force);
+        }
+
+        void generateSnapshotElementsId(StructureDefinition structureDef, bool force = false)
+        {
+            generateElementsId(structureDef.Snapshot.Element, force);
+        }
+
+        void generateElementsId(IList<ElementDefinition> elements, bool force = false)
+        {
+            var nav = new ElementDefinitionNavigator(elements);
+            generateChildElementsId(nav, force);
+        }
+
+        // (Re-)generate ElementId values for all children of the current element
+        void generateChildElementsId(ElementDefinitionNavigator nav, bool force = false)
+        {
+            var parent = nav.Current;
+            Debug.Print("generateChildElementsId: '{0}'", parent != null ? parent.Path : "[root]");
+            var bm = nav.Bookmark();
+            if (nav.MoveToFirstChild())
+            {
+                do
+                {
+                    var elem = nav.Current;
+                    if (force | string.IsNullOrEmpty(elem.ElementId))
+                    {
+                        elem.ElementId = generateElementId(elem, parent);
+                    }
+                    generateChildElementsId(nav, force);
+                } while (nav.MoveToNext());
+                nav.ReturnToBookmark(bm);
+            }
+        }
+
+        // Generate an ElementId for the specified element and parent element
+        string generateElementId(ElementDefinition element, ElementDefinition parent)
+        {
+            if (element == null) { throw new ArgumentNullException("element"); }
+            // parent is null for the resource root element
+            var id = parent != null ? parent.ElementId : null;
+            // Add element name (last path component)
+            var pathPart = ElementDefinitionNavigator.GetLastPathComponent(element.Path);
+            id = addIdComponent(id, ".", pathPart);
+            // Add element slice name (user defined), if present
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                // Chris Grenz generates compound names, e.g. [slice-name].[child-element-name]
+                // Only use the last part, and only if it differs from the xml element name
+                var localName = ElementDefinitionNavigator.GetLastPathComponent(element.Name);
+                if (localName != pathPart)
+                {
+                    id = addIdComponent(id, ":", localName);
+                }
+            }
+            return id;
+        }
+
+        string addIdComponent(string id, string separator, string component)
+        {
+            return string.IsNullOrEmpty(id) ? component : id + separator + component;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -621,6 +621,10 @@ namespace Hl7.Fhir.Specification.Snapshot
             merge(snap, diff);
 
             result = snap.ToListOfElements();
+
+            // [WMR 20160917] NEW: Re-generate all ElementId values
+            generateElementsId(result, true);
+
             return result;
         }
 
@@ -762,8 +766,8 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
 
             // Prevent endless recursion on root type Element
-            const string elemUrl = "http://hl7.org/fhir/StructureDefinition/Element";
-            if (profileUrl == elemUrl) { return true; }
+            const string ELEMENT_STRUCTURE_URL = "http://hl7.org/fhir/StructureDefinition/Element";
+            if (profileUrl == ELEMENT_STRUCTURE_URL) { return true; }
 
             // Detect endless recursion
             // Verify that the type profile is not already being expanded by a parent call higher up the call stack hierarchy

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1,13 +1,13 @@
-﻿// WORK IN PROGRESS
-// #define MERGE_PRIMITIVE_TYPES
-
-/* 
+﻿/* 
  * Copyright (c) 2016, Furore (info@furore.com) and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/master/LICENSE
  */
+
+// WORK IN PROGRESS
+// #define MERGE_PRIMITIVE_TYPES
 
 using System;
 using System.Collections.Generic;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorEvents.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorEvents.cs
@@ -29,12 +29,10 @@ namespace Hl7.Fhir.Specification.Snapshot
         internal void OnConstraint(Element element)
         {
             if (element == null) { throw new ArgumentNullException("element"); }
-            
+
             // Configurable default behavior: mark changed elements
-            if (_settings.MarkChanges)
-            {
-                element.SetChangedByDiff();
-            }
+            // [WMR 20160915] Mark element as chaged
+            markChangedByDiff(element);
 
             var handler = Constraint;
             if (handler != null)

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -78,16 +78,16 @@ namespace Hl7.Fhir.Specification.Snapshot
         //    }
         //}
 
-        ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the snapshot element definition and it's child elements.</summary>
-        ///// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
-        //public static void ClearAllChangedByDiff(this ElementDefinition elemDef)
-        //{
-        //    ClearAllExtensions(elemDef, CHANGED_BY_DIFF_EXT);
-        //}
+            ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the snapshot element definition and it's child elements.</summary>
+            ///// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
+            //public static void ClearAllChangedByDiff(this ElementDefinition elemDef)
+            //{
+            //    ClearAllExtensions(elemDef, CHANGED_BY_DIFF_EXT);
+            //}
 
-        /// <summary>Removes a specific extension from the snapshot element definition and it's descendant elements, recursively.</summary>
-        /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
-        /// <param name="uri">The canonical url of the extension.</param>
+            /// <summary>Removes a specific extension from the snapshot element definition and it's descendant elements, recursively.</summary>
+            /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
+            /// <param name="uri">The canonical url of the extension.</param>
         internal static void ClearAllExtensions(this ElementDefinition elemDef, string uri)
         {
             if (elemDef == null) return;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -1,6 +1,4 @@
-﻿#define BASE_CHILDREN
-
-/* 
+﻿/* 
  * Copyright (c) 2016, Furore (info@furore.com) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -41,7 +39,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             return element.GetBoolExtension(CHANGED_BY_DIFF_EXT);
         }
 
-        /// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the element.</summary>
+        /// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the specified element.</summary>
         /// <param name="element">An <see cref="IExtendable"/> instance.</param>
         public static void RemoveChangedByDiff(this IExtendable element)
         {
@@ -49,6 +47,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             element.RemoveExtension(CHANGED_BY_DIFF_EXT);
         }
 
+        /// <summary>Removes all instances of the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the specified element and it's child elements, recursively.</summary>
         public static void RemoveAllChangedByDiff(this Element element)
         {
             if (element == null) { throw Error.ArgumentNull("element"); }
@@ -59,6 +58,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
         }
 
+        /// <summary>Removes all instances of the <see cref="CHANGED_BY_DIFF_EXT"/> extension from all the specified elements and their children, recursively.</summary>
         public static void RemoveAllChangedByDiff<T>(this IList<T> elements) where T : Element
         {
             if (elements == null) { throw Error.ArgumentNull("elements"); }
@@ -68,71 +68,54 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
         }
 
-        ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from all snapshot element definitions and child elements.</summary>
-        ///// <param name="elemDefs">A list of <see cref="ElementDefinition"/> instances.</param>
-        //public static void ClearAllChangedByDiff(this IEnumerable<ElementDefinition> elemDefs)
-        //{
-        //    foreach (var elem in elemDefs ?? Enumerable.Empty<ElementDefinition>())
-        //    {
-        //        ClearAllChangedByDiff(elem);
-        //    }
-        //}
-
-            ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the snapshot element definition and it's child elements.</summary>
-            ///// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
-            //public static void ClearAllChangedByDiff(this ElementDefinition elemDef)
-            //{
-            //    ClearAllExtensions(elemDef, CHANGED_BY_DIFF_EXT);
-            //}
-
-            /// <summary>Removes a specific extension from the snapshot element definition and it's descendant elements, recursively.</summary>
-            /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
-            /// <param name="uri">The canonical url of the extension.</param>
+        /// <summary>Removes a specific extension from the snapshot element definition and it's descendant elements, recursively.</summary>
+        /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
+        /// <param name="uri">The canonical url of the extension.</param>
         internal static void ClearAllExtensions(this ElementDefinition elemDef, string uri)
         {
             if (elemDef == null) return;
 
-#if BASE_CHILDREN
             ClearExtensions(elemDef, uri);
-#else
-            elemDef.RemoveExtension(uri);
-            ClearAllExtensions(element.AliasElement, uri);
-            ClearExtension(element.Base, uri);
-            ClearExtension(element.Binding, uri);
-            ClearAllExtensions(element.Code, uri);
-            ClearExtension(element.CommentsElement, uri);
-            ClearAllExtensions(element.ConditionElement, uri);
-            ClearAllExtensions(element.Constraint, uri);
-            ClearExtension(element.DefaultValue, uri);
-            ClearExtension(element.DefinitionElement, uri);
-            ClearExtension(element.Example, uri);
-            ClearAllExtensions(element.Extension, uri);
-            ClearAllExtensions(element.FhirCommentsElement, uri);
-            ClearExtension(element.Fixed, uri);
-            ClearExtension(element.IsModifierElement, uri);
-            ClearExtension(element.IsSummaryElement, uri);
-            ClearExtension(element.LabelElement, uri);
-            ClearAllExtensions(element.Mapping, uri);
-            ClearExtension(element.MaxElement, uri);
-            ClearExtension(element.MaxLengthElement, uri);
-            ClearExtension(element.MaxValue, uri);
-            ClearExtension(element.MeaningWhenMissingElement, uri);
-            ClearExtension(element.MinElement, uri);
-            ClearExtension(element.MinValue, uri);
-            ClearExtension(element.MustSupportElement, uri);
-            ClearExtension(element.NameElement, uri);
-            ClearExtension(element.NameReferenceElement, uri);
-            ClearExtension(element.PathElement, uri);
-            ClearExtension(element.Pattern, uri);
-            ClearAllExtensions(element.RepresentationElement, uri);
-            ClearExtension(element.ShortElement, uri);
-            ClearExtension(element.Slicing, uri);
-            ClearExtension(element.RequirementsElement, uri);
-            ClearAllExtensions(element.Type, uri);
-#endif
+
+            // OBSOLETE - enumerate Base.Children collection
+
+            //elemDef.RemoveExtension(uri);
+            //ClearAllExtensions(element.AliasElement, uri);
+            //ClearExtension(element.Base, uri);
+            //ClearExtension(element.Binding, uri);
+            //ClearAllExtensions(element.Code, uri);
+            //ClearExtension(element.CommentsElement, uri);
+            //ClearAllExtensions(element.ConditionElement, uri);
+            //ClearAllExtensions(element.Constraint, uri);
+            //ClearExtension(element.DefaultValue, uri);
+            //ClearExtension(element.DefinitionElement, uri);
+            //ClearExtension(element.Example, uri);
+            //ClearAllExtensions(element.Extension, uri);
+            //ClearAllExtensions(element.FhirCommentsElement, uri);
+            //ClearExtension(element.Fixed, uri);
+            //ClearExtension(element.IsModifierElement, uri);
+            //ClearExtension(element.IsSummaryElement, uri);
+            //ClearExtension(element.LabelElement, uri);
+            //ClearAllExtensions(element.Mapping, uri);
+            //ClearExtension(element.MaxElement, uri);
+            //ClearExtension(element.MaxLengthElement, uri);
+            //ClearExtension(element.MaxValue, uri);
+            //ClearExtension(element.MeaningWhenMissingElement, uri);
+            //ClearExtension(element.MinElement, uri);
+            //ClearExtension(element.MinValue, uri);
+            //ClearExtension(element.MustSupportElement, uri);
+            //ClearExtension(element.NameElement, uri);
+            //ClearExtension(element.NameReferenceElement, uri);
+            //ClearExtension(element.PathElement, uri);
+            //ClearExtension(element.Pattern, uri);
+            //ClearAllExtensions(element.RepresentationElement, uri);
+            //ClearExtension(element.ShortElement, uri);
+            //ClearExtension(element.Slicing, uri);
+            //ClearExtension(element.RequirementsElement, uri);
+            //ClearAllExtensions(element.Type, uri);
+
         }
 
-#if BASE_CHILDREN
         static void ClearExtensions<T>(this IEnumerable<T> elements, string uri) where T : Base
         {
             if (elements != null)
@@ -152,17 +135,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 ClearExtensions(element.Children, uri);
             }
         }
-#else
-        internal static void ClearAllExtensions<T>(this IList<T> extendables, string uri) where T : IExtendable
-        {
-            if (extendables == null) return;
-            foreach (var ext in extendables)
-            {
-                ClearExtension(ext, uri);
-            }
-        }
 
-#endif
         static void ClearExtension(this IExtendable extendable, string uri)
         {
             if (extendable != null) { extendable.RemoveExtension(uri); }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -43,28 +43,47 @@ namespace Hl7.Fhir.Specification.Snapshot
 
         /// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the element.</summary>
         /// <param name="element">An <see cref="IExtendable"/> instance.</param>
-        public static void ClearChangedByDiff(this IExtendable element)
+        public static void RemoveChangedByDiff(this IExtendable element)
         {
             if (element == null) { throw Error.ArgumentNull("element"); }
             element.RemoveExtension(CHANGED_BY_DIFF_EXT);
         }
 
-        /// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from all snapshot element definitions and child elements.</summary>
-        /// <param name="elemDefs">A list of <see cref="ElementDefinition"/> instances.</param>
-        public static void ClearAllChangedByDiff(this IEnumerable<ElementDefinition> elemDefs)
+        public static void RemoveAllChangedByDiff(this Element element)
         {
-            foreach (var elem in elemDefs ?? Enumerable.Empty<ElementDefinition>())
+            if (element == null) { throw Error.ArgumentNull("element"); }
+            element.RemoveChangedByDiff();
+            foreach (var child in element.Children.OfType<Element>())
             {
-                ClearAllChangedByDiff(elem);
+                child.RemoveAllChangedByDiff();
             }
         }
 
-        /// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the snapshot element definition and it's child elements.</summary>
-        /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
-        public static void ClearAllChangedByDiff(this ElementDefinition elemDef)
+        public static void RemoveAllChangedByDiff<T>(this IList<T> elements) where T : Element
         {
-            ClearAllExtensions(elemDef, CHANGED_BY_DIFF_EXT);
+            if (elements == null) { throw Error.ArgumentNull("elements"); }
+            foreach (var elem in elements)
+            {
+                elem.RemoveAllChangedByDiff();
+            }
         }
+
+        ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from all snapshot element definitions and child elements.</summary>
+        ///// <param name="elemDefs">A list of <see cref="ElementDefinition"/> instances.</param>
+        //public static void ClearAllChangedByDiff(this IEnumerable<ElementDefinition> elemDefs)
+        //{
+        //    foreach (var elem in elemDefs ?? Enumerable.Empty<ElementDefinition>())
+        //    {
+        //        ClearAllChangedByDiff(elem);
+        //    }
+        //}
+
+        ///// <summary>Removes the <see cref="CHANGED_BY_DIFF_EXT"/> extension from the snapshot element definition and it's child elements.</summary>
+        ///// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>
+        //public static void ClearAllChangedByDiff(this ElementDefinition elemDef)
+        //{
+        //    ClearAllExtensions(elemDef, CHANGED_BY_DIFF_EXT);
+        //}
 
         /// <summary>Removes a specific extension from the snapshot element definition and it's descendant elements, recursively.</summary>
         /// <param name="elemDef">An <see cref="ElementDefinition"/> instance.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -15,7 +15,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         public static readonly SnapshotGeneratorSettings Default = new SnapshotGeneratorSettings()
         {
             ExpandExternalProfiles = true,
-            ForceExpandAll = false,
+            ForceExpandAll = false, // Only enable this when using a cached source...
             MarkChanges = false,
             // Following settings are proposed and await approval from HL7 WGM
             MergeTypeProfiles = true,


### PR DESCRIPTION
Also raise PrepareElement event for newly introduced elements (in core structure definitions)
Fix ChangedByDiff extension logic, derived profiles should not inherit this extension.
Also the extension should not affect comparisons between derived and base elements.
=> After resolving and cloning the base profile and element type profiles, first remove all instances of this extension.