### PR TITLE
PocoElement Navigator positiveint type conversion

### DIFF
--- a/src/Hl7.Fhir.Core/FluentPath/PocoElementNavigator.cs
+++ b/src/Hl7.Fhir.Core/FluentPath/PocoElementNavigator.cs
@@ -84,6 +84,12 @@ namespace Hl7.Fhir.FluentPath
                             return (long)(_pocoElement as Integer).Value.Value;
                         return null;
                     }
+                    else if ((_pocoElement is PositiveInt))
+                    {
+                        if ((_pocoElement as Integer).Value.HasValue)
+                            return (long)(_pocoElement as PositiveInt).Value.Value;
+                        return null;
+                    }
                     else if (_pocoElement is Primitive)
                         return ((Primitive)_pocoElement).ObjectValue;
                     else


### PR DESCRIPTION
Convert the FHIR PositiveInt type to a fluentpath compatible value (which is a long, not an int)
use case is that this fluentpath expression won't work due to a type incompatibility
"Patient.telecom.where(system = 'phone' and rank = 1).exists()"
1 is a **long** (Int64) in fluentpath, however the positiveInt is returned to fluentpath from the poconavigator as an **int** (Int32)