### PR TITLE
Fix inconsistent URI encoding for Bundle links

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -82,6 +82,34 @@ namespace Hl7.Fhir.Tests.Model
        
 
         [TestMethod]
+        public void TestBundleLinkEncoding()
+        {
+            Action<string> test = (urlFormat) =>
+            {
+                var param1 = "baz/123";
+                var param2 = "qux:456";
+                var manuallyEncodedUrl = string.Format(urlFormat, "baz%2F123", "qux%3A456");
+                var uriEncodedUrl = string.Format(urlFormat, Uri.EscapeDataString(param1), Uri.EscapeDataString(param2));
+                Assert.AreEqual(manuallyEncodedUrl, uriEncodedUrl);
+                var uri = new Uri(manuallyEncodedUrl, UriKind.RelativeOrAbsolute);
+                var bundle = new Bundle {SelfLink = uri};
+                if (uri.IsAbsoluteUri)
+                {
+                    Assert.AreEqual(uri.AbsoluteUri, bundle.SelfLink.AbsoluteUri);
+                }
+                else
+                {
+                    Assert.AreEqual(uri.OriginalString, bundle.SelfLink.OriginalString);
+                }
+            };
+
+            test("http://foo/bar?param1={0}&param2={1}");
+            test("http://foo/bar/../bar?param1={0}&param2={1}");
+            test("bar?param1={0}&param2={1}");
+            test("bar/../bar?param1={0}&param2={1}");
+        }
+
+        [TestMethod]
         public void SimpleValueSupport()
         {
             Conformance c = new Conformance();

--- a/src/Hl7.Fhir.Core/Model/Bundle.cs
+++ b/src/Hl7.Fhir.Core/Model/Bundle.cs
@@ -154,10 +154,11 @@ namespace Hl7.Fhir.Model
 
             var entry = Link.FirstOrDefault(e => rel.Equals(e.Relation, StringComparison.OrdinalIgnoreCase));
 
+            var uriString = uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.OriginalString;
             if (entry != null)
-                entry.Url = uri.ToString();
+                entry.Url = uriString;
             else
-                Link.Add(new LinkComponent() { Relation = rel, Url = uri.ToString() });
+                Link.Add(new LinkComponent() { Relation = rel, Url = uriString });
         }
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)


### PR DESCRIPTION
The Bundle class is currently using the `Uri.ToString()` method to store the various links. The `Uri.ToString()` method does preserve URL encoding. According to the documentation, `Uri.ToString()` unescapes all characters except #, ?, and %.

For example if one were to set the SelfLink property to `http://foo/bar?p1=a%2Fb&p2=c%3Ad` and subsquently retrieved the value, the resulting `SelfLink.AbsoluteUri` and `SelfLink.OriginalString` property values would both then be `http://foo/bar?p1=a%2Fb&p2=c:d`. Note that the `%3A` gets decoded. We do not believe this to be the desired behavior.

The fix for this issue to avoid the `Uri.ToString()` method in storing the links and leverage either the `Uri.AbsoluteUri` property for absolute `Uri`s or the `Uri.OriginalString` property for relative `Uri`s.

- https://msdn.microsoft.com/en-us/library/system.uri.tostring(v=vs.110).aspx
- http://stackoverflow.com/questions/7624987/whats-the-difference-between-uri-tostring-and-uri-absoluteuri
- https://code.logos.com/blog/2010/08/uritostring_must_die.html