### PR TITLE
bugfix: SnapshotGenerator.mergeTypeProfiles - OnPrepareElement event …

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -177,7 +177,9 @@ namespace Hl7.Fhir.Specification.Tests
             // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Composition");
 
             // [WMR 20170110] Test problematic extension
-            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/us-core-direct");
+            // var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/us-core-direct");
+
+            var sd = _testResolver.FindStructureDefinition(@"http://hl7.org/fhir/StructureDefinition/Account");
 
             Assert.IsNotNull(sd);
 
@@ -2736,8 +2738,9 @@ namespace Hl7.Fhir.Specification.Tests
             var baseElem = extElem.Annotation<BaseDefAnnotation>().BaseElementDefinition;
             Assert.IsNotNull(baseElem);
             Assert.AreEqual(baseElem.Short, extElem.Short);
+            Assert.AreEqual(baseElem.Definition, extElem.Definition);
             Assert.AreEqual(baseElem.Comments, extElem.Comments);
-            // Assert.AreEqual(baseElem.Alias, extElem.Alias);
+            Assert.IsTrue(baseElem.Alias.SequenceEqual(extElem.Alias));
         }
 
     }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -626,7 +626,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     return false;
                 }
 
-                // [WMR 20170110] Also notify about type profiles!
+                // [WMR 20170110] Also notify about type profiles
                 OnPrepareElement(snap.Current, typeStructure, typeStructure.Snapshot.Element[0]);
 
                 // Clone and rebase
@@ -665,7 +665,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var typeRootElem = getSnapshotRootElement(typeStructure, primaryDiffTypeProfile, diffNode);
                 if (typeRootElem == null) { return false; }
 
-                // [WMR 20170105] Notify observers!
+                // [WMR 20170110] Also notify about type profiles
                 OnPrepareElement(snap.Current, typeStructure, typeRootElem);
 
                 // Rebase before merging
@@ -674,8 +674,12 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Merge the type profile root element; no need to expand children
                 mergeElementDefinition(snap.Current, rebasedRootElem);
-
             }
+
+            // [WMR 20170111] Notify about merged base element (base profile | type profile), before merging diff constraints
+            var mergedBaseElem = (ElementDefinition)snap.Current.DeepCopy();
+            OnPrepareElement(snap.Current, null, mergedBaseElem);
+
             return true;
         }
 


### PR DESCRIPTION
bugfix: SnapshotGenerator.mergeTypeProfiles - OnPrepareElement event should provide merged base element (base profile | type profile), before merging diff constraints