### PR TITLE
Snapshot Generator - accept slices on non-repeating, non-choice type elements

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
@@ -136,6 +136,9 @@
     <Content Include="TestData\snapshot-test\WMR\MyCustomObservation3.structuredefinition.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\snapshot-test\WMR\MySlicedOrganization.structuredefinition.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\snapshot-test\WMR\ObservationLabelExtension.structuredefinition.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -3048,6 +3048,38 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(baseElem.Comments, extElem.Comments);
             Assert.IsTrue(baseElem.Alias.SequenceEqual(extElem.Alias));
         }
+
+        // [WMR 20170213] New - issue reported by Marten - cannot slice Organization.type ?
+        // Specifically, snapshot generator drops the slicing component from the slice entry element
+        // Explanation: Organization.type is not a list (max = 1) and not a choice type => slicing is not allowed!
+        [TestMethod]
+        [Ignore]
+        public void TestOrganizationTypeSlice()
+        {
+            var org = _testResolver.FindStructureDefinition(@"http://example.org/fhir/StructureDefinition/MySlicedOrganization");
+            Assert.IsNotNull(org);
+
+            StructureDefinition expanded;
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            _generator.PrepareElement += elementHandler;
+            try
+            {
+                generateSnapshotAndCompare(org, out expanded);
+            }
+            finally
+            {
+                _generator.PrepareElement -= elementHandler;
+            }
+
+            dumpOutcome(_generator.Outcome);
+
+            var elems = expanded.Snapshot.Element;
+            dumpElements(elems);
+            //dumpBaseElems(elems);
+
+            // TODO: Verify slice
+
+        }
     }
 
     public static class IListExtensions

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MySlicedOrganization.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/WMR/MySlicedOrganization.structuredefinition.xml
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <meta>
+    <lastUpdated value="2017-02-13T15:50:01.983+01:00" />
+  </meta>
+  <url value="http://example.org/fhir/StructureDefinition/MySlicedOrganization" />
+  <name value="MySlicedOrganization" />
+  <status value="draft" />
+  <date value="2017-02-13T15:45:05.4075449+01:00" />
+  <kind value="resource" />
+  <constrainedType value="Organization" />
+  <abstract value="false" />
+  <base value="http://hl7.org/fhir/StructureDefinition/Organization" />
+  <differential>
+    <element>
+      <path value="Organization" />
+    </element>
+    <element>
+      <path value="Organization.identifier" />
+      <slicing>
+        <discriminator value="type.coding.system" />
+        <rules value="openAtEnd" />
+      </slicing>
+    </element>
+    <element>
+      <path value="Organization.identifier" />
+      <name value="I1" />
+    </element>
+    <element>
+      <path value="Organization.identifier" />
+      <name value="I2" />
+    </element>
+    <element>
+      <path value="Organization.type" />
+      <slicing>
+        <discriminator value="coding.system" />
+        <rules value="openAtEnd" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element>
+      <path value="Organization.type" />
+      <name value="T1" />
+    </element>
+    <element>
+      <path value="Organization.type" />
+      <name value="T2" />
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Related to issue reported by Marten Smits.
As discussed with Ewout, there is no (technical) reason for API not to accept this.
So I've simply removed the explicit check.

However, Vadim commented that this may introduce issues for code generators...