### PR TITLE
bugfix: snapshot generator - properly merge complex components (e.g. binding)

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SnapshotGeneratorTest.cs
@@ -3280,6 +3280,12 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(expanded.HasSnapshot);
 
             dumpOutcome(_generator.Outcome);
+
+            Assert.IsNotNull(_generator.Outcome);
+            Assert.IsNotNull(_generator.Outcome.Issue);
+            Assert.AreEqual(2, _generator.Outcome.Issue.Count);
+            assertIssue(_generator.Outcome.Issue[1], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE);
+
             dumpElements(expanded.Snapshot.Element);
         }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -238,10 +238,20 @@ namespace Hl7.Fhir.Specification.Snapshot
                     }
                     else if (!diff.IsExactly(snap))
                     {
-                        // Clone base and recursively copy all non-null diff props over base props
-                        // So effectively the result inherits all missing properties from base
-                        result = (T)snap.DeepCopy();
-                        diff.CopyTo(result);
+                        if (snap.GetType().IsAssignableFrom(diff.GetType()))
+                        {
+                            // [WMR 20170227] Diff type is equal to or derived from snap type
+                            // Clone base and recursively copy all non-null diff props over base props
+                            // So effectively the result inherits all missing properties from base
+                            result = (T)snap.DeepCopy();
+                            diff.CopyTo(result);
+                        }
+                        else
+                        {
+                            // [WMR 20170227] Diff type is incompatible with snap type (?)
+                            // diff fully replaces snap
+                            result = (T)diff.DeepCopy();
+                        }
                         onConstraint(result);
                     }
                 }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -666,7 +666,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             var typeStructure = _resolver.FindStructureDefinition(primaryDiffTypeProfile);
 
             // [WMR 20170224] Verify that the resolved StructureDefinition is compatible with the element type
-            if (!isValidTypeConstraint(typeStructure, primarySnapType.Code))
+            if (!_resolver.IsValidTypeProfile(primarySnapType.Code, typeStructure))
             {
                 addIssueInvalidProfileType(diff.Current, typeStructure);
                 return false;
@@ -757,28 +757,6 @@ namespace Hl7.Fhir.Specification.Snapshot
             OnPrepareElement(snap.Current, null, mergedBaseElem);
 
             return true;
-        }
-
-        /// <summary>Determines if the specified <see cref="StructureDefinition"/> is compatible with type <param name="baseType"/>.</summary>
-        /// <returns><c>true</c> if the profile type is equal to or derived from the specified type, or <c>false</c> otherwise.</returns>
-        bool isValidTypeConstraint(StructureDefinition sd, FHIRDefinedType? baseType)
-        {
-            // Recursively walk up the base profile hierarchy until we find a profile on baseType
-            // TODO: Cache results...
-
-            if (baseType == null) { return true; }
-            if (sd == null) { return true; }
-
-            // DSTU2: sd.ConstrainedType is empty for core definitions => resolve from sd.Name
-            // STU3: sd.Type is always specified, including for core definitions
-            var sdType = sd.ConstrainedType ?? ModelInfo.FhirTypeNameToFhirType(sd?.Name);
-            if (sdType == null) { return false; }
-
-            if (sdType == baseType) { return true; }
-            if (sd.Base == null) { return false; }
-            var sdBase = _resolver.FindStructureDefinition(sd.Base);
-            if (sdBase == null) { return false; }
-            return isValidTypeConstraint(sdBase, baseType);
         }
 
         // [WMR 20170209] HACK

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorOutcome.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorOutcome.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.Model;
 using Hl7.ElementModel;
 using Hl7.Fhir.Support;
 using System.Linq;
+using Hl7.Fhir.Specification.Navigation;
 
 // [WMR 20160907] TODO: Create unit tests to evaluate behavior for different kinds of errors, e.g.
 // - unresolved external (type/extension) profile
@@ -270,6 +271,24 @@ namespace Hl7.Fhir.Specification.Snapshot
             return PROFILE_ELEMENTDEF_INVALID_SLICE_WITHOUT_NAME.ToIssueComponent(
                 $"Element {location} defines a slice without a name. Individual slices must always have a unique name, except extensions.",
                 location
+            );
+        }
+
+        // [WMR 20170224] NEW - ElementDefinition.Type.Profile target profile has the wrong type
+        // e.g. if a profile extension references a StructureDefinition that is not an Extension Definition.
+        // or if Identifier element type references a Location profile
+        public static readonly Issue PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE = Issue.Create(10009, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+
+        internal OperationOutcome.IssueComponent addIssueInvalidProfileType(ElementDefinition elementDef, StructureDefinition profile)
+        {
+            var location = elementDef.ToNamedNode();
+            var elemType = elementDef.PrimaryTypeCode();
+            var profileType = profile.ConstrainedType ?? ModelInfo.FhirTypeNameToFhirType(profile?.Name);
+            return addIssue(
+                PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE.ToIssueComponent(
+                    $"Element {location} has an invalid type profile constraint '{profile.Url}'. The target represents a profile on '{profileType}' which is incompatible with the element type '{elemType}'.",
+                    location
+                )
             );
         }
 

--- a/src/Hl7.Fhir.Specification/Specification/Source/ResourceResolverExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ResourceResolverExtensions.cs
@@ -106,5 +106,54 @@ namespace Hl7.Fhir.Specification.Source
             return sd;
         }
 
+        // [WMR 20170227] NEW
+        // TODO:
+        // - Analyze possible re-use by Validator
+        // - Maybe move this method to another (public) class?
+
+        /// <summary>
+        /// Determines if the specified <see cref="StructureDefinition"/> is compatible with <paramref name="type"/>.
+        /// Walks up the profile hierarchy by resolving base profiles from the current <see cref="IResourceResolver"/> instance.
+        /// </summary>
+        /// <returns><c>true</c> if the profile type is equal to or derived from the specified type, or <c>false</c> otherwise.</returns>
+        /// <param name="resolver">A resource resolver instance.</param>
+        /// <param name="type">A FHIR type.</param>
+        /// <param name="profile">A StructureDefinition instance.</param>
+        public static bool IsValidTypeProfile(this IResourceResolver resolver, FHIRDefinedType? type, StructureDefinition profile)
+        {
+            if (resolver == null) { throw new ArgumentNullException(nameof(resolver)); }
+            return isValidTypeProfile(resolver, new Stack<string>(), type, profile);
+        }
+
+        static bool isValidTypeProfile(this IResourceResolver resolver, Stack<string> recursionStack, FHIRDefinedType? type, StructureDefinition profile)
+        {
+            // Recursively walk up the base profile hierarchy until we find a profile on baseType
+            if (type == null) { return true; }
+            if (profile == null) { return true; }
+
+            // DSTU2: sd.ConstrainedType is empty for core definitions => resolve from sd.Name
+            // STU3: sd.Type is always specified, including for core definitions
+            var sdType = profile.ConstrainedType ?? ModelInfo.FhirTypeNameToFhirType(profile?.Name);
+            if (sdType == null) { return false; }
+
+            if (sdType == type) { return true; }
+            if (profile.Base == null) { return false; }
+            var sdBase = resolver.FindStructureDefinition(profile.Base);
+            if (sdBase == null) { return false; }
+            if (sdBase.Url == null) { return false; } // Shouldn't happen...
+
+            // [WMR 20170227] TODO: Detect/prevent endless recursion... e.g. B.Base = A and A.Base = B
+            // if (recursionStack == null) { recursionStack = new Stack<string>(); }
+            if (recursionStack.Contains(sdBase.Url))
+            {
+                throw Error.InvalidOperation(
+                    $"Recursive profile dependency detected. Base profile hierarchy:\r\n{string.Join("\r\n", recursionStack)}"
+                );
+            }
+            recursionStack.Push(sdBase.Url);
+
+            return isValidTypeProfile(resolver, recursionStack, type, sdBase);
+        }
+
     }
 }


### PR DESCRIPTION
Bugfix for an issue originally reported by NHS.

Symptom: if profile constrains binding.strength, then the snapshot should inherit .description and .valueSet[x] from the base profile. However actually the snapshot only contains the .strength constraint; the inherited properties are missing.

Intended behavior: The snapshot generator should recursively merge all unconstrained properties (not present in diff) from base profile.

=> Fixed method ElementDefnMerger.mergeComplexAttribute
=> Add unit test SnapshotGeneratorTest.TestElementBinding

[Edit] Added another commit to reject invalid element type profiles with incompatible target type.
Example 1: profile extension element mapped to a StructureDefinition that is not an extension definition.
Example 2: Patient.identifier element mapped to Location profile

[Edit 2] Moved to common extension method ResourceResolverExtensions.IsValidTypeProfile
Ewout: Maybe move this method to another (common public) class?