### PR TITLE
bugfix: SnapshotGenerator - fix choice type elements

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
@@ -143,7 +143,7 @@
     <Content Include="TestData\snapshot-test\Marten\nl-core-patient-snapshot.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestData\snapshot-test\Vadim\KulePrescribing.structuredefinition.xml">
+    <Content Include="TestData\snapshot-test\Vadim\MedicationStatement-prescribing.structuredefinition.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\snapshot-test\WMR\CustomIdentifier.structuredefinition.xml">

--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Net45.Tests.csproj
@@ -143,6 +143,9 @@
     <Content Include="TestData\snapshot-test\Marten\nl-core-patient-snapshot.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\snapshot-test\Vadim\KulePrescribing.structuredefinition.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\snapshot-test\WMR\CustomIdentifier.structuredefinition.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1550,7 +1550,7 @@ namespace Hl7.Fhir.Specification.Tests
                 // Note: diff elem is not exactly equal to base elem (due to reduntant type profile constraint)
                 // hasConstraints and hasChanges methods aren't smart enough to detect redundant constraints
                 var hasConstraints = SnapshotGeneratorTest.hasConstraints(elem, baseElem);
-                Assert.IsTrue(hasConstraints);      
+                Assert.IsTrue(hasConstraints);
                 Assert.IsTrue(hasChanges(elem));
 
                 // Verify base annotations on Patient.identifier subtree
@@ -3282,7 +3282,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             var nav = ElementDefinitionNavigator.ForSnapshot(expanded);
             Assert.IsTrue(nav.MoveToFirstChild());
-            
+
             // Verify slice entry
             Assert.IsTrue(nav.MoveToChild("identifier"));
             Assert.AreEqual(corePatientIdentifierElem, GetBaseElementAnnotation(nav.Current));
@@ -3831,6 +3831,197 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(nav.ReturnToBookmark(bm));
         }
 
+        [TestMethod]
+        public void TestElementMappings()
+        {
+            var profile = _testResolver.FindStructureDefinition("http://hl7.no/fhir/StructureDefinition/kule-prescribing");
+            Assert.IsNotNull(profile);
+
+            var diffElem = profile.Differential.Element.FirstOrDefault(e => e.Path == "MedicationStatement.informationSource");
+            Assert.IsNotNull(diffElem);
+            dumpMappings(diffElem);
+
+            StructureDefinition expanded = null;
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            _generator.PrepareElement += elementHandler;
+            try
+            {
+                generateSnapshotAndCompare(profile, out expanded);
+            }
+            finally
+            {
+                _generator.PrepareElement -= elementHandler;
+            }
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+
+            var elems = expanded.Snapshot.Element;
+            dumpElements(elems);
+
+            var elem = elems.FirstOrDefault(e => e.Path == "MedicationStatement.informationSource");
+            Assert.IsNotNull(elem);
+            dumpMappings(elem);
+
+            // Snapshot element mappings should include all of the differential element mappings
+            Assert.IsTrue(diffElem.Mapping.All(dm => elem.Mapping.Any(m => m.IsExactly(dm))));
+
+        }
+
+        static void dumpMappings(ElementDefinition elem) => dumpMappings(elem.Mapping, $"Mappings for {elem.Path}:");
+
+        static void dumpMappings(IList<ElementDefinition.MappingComponent> mappings, string header = null)
+        {
+            Debug.WriteLineIf(header != null, header);
+            foreach (var mapping in mappings)
+            {
+                Debug.Print($"{mapping.Identity} : {mapping.Map}");
+            }
+        }
+
+        // Ewout: type slices cannot contain renamed elements!
+
+        static StructureDefinition PatientNonTypeSliceProfile => new StructureDefinition()
+        {
+            ConstrainedType = FHIRDefinedType.Patient,
+            Base = ModelInfo.CanonicalUriForFhirCoreType(FHIRDefinedType.Patient),
+            Name = "NonTypeSlicePatient",
+            Url = "http://example.org/fhir/StructureDefinition/NonTypeSlicePatient",
+            Differential = new StructureDefinition.DifferentialComponent()
+            {
+                Element = new List<ElementDefinition>()
+                {
+                    new ElementDefinition("Patient.deceased[x]")
+                    {
+                        Min = 1,
+                        // Repeat the base element types (no additional constraints)
+                        Type = new List<ElementDefinition.TypeRefComponent>()
+                        {
+                            new ElementDefinition.TypeRefComponent() { Code = FHIRDefinedType.Boolean },
+                            new ElementDefinition.TypeRefComponent() { Code = FHIRDefinedType.DateTime }
+                        }
+                    }
+                }
+            }
+        };
+
+        [TestMethod]
+        public void TestPatientNonTypeSlice()
+        {
+            var profile = PatientNonTypeSliceProfile;
+
+            var resolver = new InMemoryProfileResolver(profile);
+            var multiResolver = new MultiResolver(_testResolver, resolver);
+            _generator = new SnapshotGenerator(multiResolver);
+
+            //StructureDefinition expanded = null;
+            //generateSnapshotAndCompare(profile, out expanded);
+
+            //_generator.BeforeExpandElement += beforeExpandElementHandler;
+            //StructureDefinition expanded = null;
+            //try
+            //{
+            //    generateSnapshotAndCompare(profile, out expanded);
+            //}
+            //finally
+            //{
+            //    _generator.BeforeExpandElement -= beforeExpandElementHandler;
+            //}
+            //Assert.IsNotNull(expanded);
+            //Assert.IsTrue(expanded.HasSnapshot);
+            //dumpElements(expanded.Snapshot.Element);
+            //dumpOutcome(_generator.Outcome);
+
+            // Force expansion of Patient.deceased[x]
+            var nav = ElementDefinitionNavigator.ForDifferential(profile);
+            Assert.IsTrue(nav.MoveToFirstChild());
+            var result = _generator.ExpandElement(nav);
+            dumpElements(profile.Differential.Element);
+            dumpOutcome(_generator.Outcome);
+            Assert.IsTrue(result);
+
+            Assert.IsNull(_generator.Outcome);
+        }
+
+        // Ewout: type slices cannot contain renamed elements!
+        static StructureDefinition ObservationSimpleQuantityProfile => new StructureDefinition()
+        {
+            ConstrainedType = FHIRDefinedType.Observation,
+            Base = ModelInfo.CanonicalUriForFhirCoreType(FHIRDefinedType.Observation),
+            Name = "NonTypeSlicePatient",
+            Url = "http://example.org/fhir/StructureDefinition/ObservationSimpleQuantityProfile",
+            Differential = new StructureDefinition.DifferentialComponent()
+            {
+                Element = new List<ElementDefinition>()
+                {
+                    new ElementDefinition("Observation.valueQuantity")
+                    {
+                        // Repeat the base element types (no additional constraints)
+                        Type = new List<ElementDefinition.TypeRefComponent>()
+                        {
+                            new ElementDefinition.TypeRefComponent()
+                            {
+                                // Constrain Quantity to SimpleQuantity
+                                // Code = FHIRDefinedType.Quantity,
+                                // Profile = new string[] { ModelInfo.CanonicalUriForFhirCoreType(FHIRDefinedType.SimpleQuantity) }
+
+                                Code = FHIRDefinedType.SimpleQuantity
+                            },
+                        }
+                    }
+                }
+            }
+        };
+
+        // [WMR 20170321] NEW
+        [TestMethod]
+        public void TestSimpleQuantityProfile()
+        {
+            var profile = ObservationSimpleQuantityProfile;
+
+            var resolver = new InMemoryProfileResolver(profile);
+            var multiResolver = new MultiResolver(_testResolver, resolver);
+            _generator = new SnapshotGenerator(multiResolver);
+
+            _generator.BeforeExpandElement += beforeExpandElementHandler;
+            StructureDefinition expanded = null;
+            try
+            {
+                generateSnapshotAndCompare(profile, out expanded);
+            }
+            finally
+            {
+                _generator.BeforeExpandElement -= beforeExpandElementHandler;
+            }
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+            dumpElements(expanded.Snapshot.Element.Where(e => e.Path.StartsWith("Observation.value")));
+            dumpOutcome(_generator.Outcome);
+
+            // Force expansion of Observation.valueQuantity
+            //var nav = ElementDefinitionNavigator.ForDifferential(profile);
+            //Assert.IsTrue(nav.MoveToFirstChild());
+            //var result = _generator.ExpandElement(nav);
+            //dumpElements(profile.Differential.Element);
+            //dumpOutcome(_generator.Outcome);
+            //Assert.IsTrue(result);
+            Assert.IsNull(_generator.Outcome);
+
+            // Ensure that renamed diff elements override base elements with original names
+            var nav = ElementDefinitionNavigator.ForSnapshot(expanded);
+            // Snapshot should not contain elements with original name
+            Assert.IsFalse(nav.JumpToFirst("Observation.value[x]"));
+            // Snapshot should contain renamed elements
+            Assert.IsTrue(nav.JumpToFirst("Observation.valueQuantity"));
+            Assert.IsNotNull(nav.Current.Type);
+            Assert.AreEqual(1, nav.Current.Type.Count);
+            // Assert.AreEqual(FHIRDefinedType.SimpleQuantity, nav.Current.Type[0].Code);
+            // Assert.AreEqual(FHIRDefinedType.Quantity, nav.Current.Type[0].Code);
+
+            var type = nav.Current.Type.First();
+            Debug.Print($"{nav.Path} : {type.Code} - '{type.Profile.FirstOrDefault()}'");
+        }
     }
 
 }

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -3834,7 +3834,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestElementMappings()
         {
-            var profile = _testResolver.FindStructureDefinition("http://hl7.no/fhir/StructureDefinition/kule-prescribing");
+            var profile = _testResolver.FindStructureDefinition("http://example.org/fhir/StructureDefinition/TestMedicationStatement-prescribing");
             Assert.IsNotNull(profile);
 
             var diffElem = profile.Differential.Element.FirstOrDefault(e => e.Path == "MedicationStatement.informationSource");

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Vadim/KulePrescribing.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Vadim/KulePrescribing.structuredefinition.xml
@@ -1,0 +1,563 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="kule-prescribing" />
+  <meta>
+    <lastUpdated value="2017-03-13T11:39:46.369+01:00" />
+  </meta>
+  <text>
+    <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml">
+  <p>A profile on MedicationStatement describing a prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard.</p>
+</div></text>
+  <url value="http://hl7.no/fhir/StructureDefinition/kule-prescribing" />
+  <name value="KULE Prescribing" />
+  <status value="draft" />
+  <experimental value="false" />
+  <publisher value="HL7 Norge" />
+  <date value="2017-01-27T13:11:14.8692835+01:00" />
+  <description value="A prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard." />
+  <kind value="resource" />
+  <constrainedType value="MedicationStatement" />
+  <abstract value="false" />
+  <base value="http://hl7.org/fhir/StructureDefinition/MedicationStatement" />
+  <differential>
+    <element>
+      <path value="MedicationStatement" />
+      <short value="KULE Prescribing profile." />
+      <definition value="A prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard." />
+      <constraint>
+        <key value="kuleprescribing" />
+        <severity value="error" />
+        <human value="Reason not taken must be filled if wasNotTaken is true" />
+        <xpath value="f:wasNotTaken/@value=false() or exists(f:wasNotTaken)" />
+      </constraint>
+    </element>
+    <element>
+      <path value="MedicationStatement.extension" />
+      <slicing>
+        <discriminator value="url" />
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element>
+      <path value="MedicationStatement.extension" />
+      <name value="authoredOn" />
+      <definition value="Dato for forskrivning." />
+      <alias value="authoredOn" />
+      <alias value="Forskrivningsdato" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/mp9-authored-on" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.Forskrivningsdato" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.extension" />
+      <name value="drugUseType" />
+      <alias value="Bruk" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/drug-use-type" />
+      </type>
+      <mustSupport value="true" />
+      <binding>
+        <strength value="required" />
+        <description value="Angir bruk av et legemiddel, f.eks. om det benyttes fast eller gis ved behov (OID=9101)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/f552702d-e769-4c4b-9fa5-0512c9ffe66b" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Resept.Forskrivning.Bruk" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.informationSource" />
+      <alias value="Helseperson" />
+      <alias value="Organisasjon" />
+      <type>
+        <code value="Reference" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/noPractitioner" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.Instituert.Helseperson" />
+      </mapping>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.Instituert.Organisasjon" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.status" />
+      <requirements value=" " />
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.status.modifierExtension" />
+      <slicing>
+        <discriminator value="url" />
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element>
+      <path value="MedicationStatement.status.modifierExtension" />
+      <name value="prescriptionStatus" />
+      <comments value="Receiving systems should prioritise prescririptionStatus over status if it's present.&#xD;&#xA;&#xD;&#xA;When the prescrtiptionStatus is set to 'on-hold', MedicationStatement.status should be set to 'intended'." />
+      <requirements value="The need to set the status on a MedicationStatement to 'paused' when the resource is used as a prescription of medication." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/prescription-status" />
+      </type>
+      <meaningWhenMissing value="Code needed is available in MedicationStatement.status and the extended code was not required." />
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.status.modifierExtension.valueCode" />
+      <binding>
+        <strength value="required" />
+      </binding>
+    </element>
+    <element>
+      <path value="MedicationStatement.wasNotTaken" />
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.reasonNotTaken" />
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.reasonForUse[x]" />
+      <alias value="Bruksomrade" />
+      <mustSupport value="true" />
+      <binding>
+        <strength value="required" />
+        <description value="Angir bruksområde for legemiddel. Det overføres til M1 og blir med på utskrift på apoteketikett. Brukes i FEST og Eresept (OID=7488)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/c877187c-f362-4425-827b-db2192001969" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Bruksomrade" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.effectivePeriod" />
+      <type>
+        <code value="Period" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.effectivePeriod.start" />
+      <definition value="Time when the dosage starts." />
+      <alias value="Starttidspunkt" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Starttidspunkt" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.effectivePeriod.end" />
+      <definition value="Time when the dosage ends." />
+      <alias value="Sluttidspunkt" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Sluttidspunkt" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.note" />
+      <short value="Important information about the usage of the medication." />
+      <definition value="Important information about the usage of the medication." />
+      <alias value="Merknad" />
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.EkspAnm.Merknad" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.medicationReference" />
+      <type>
+        <code value="Reference" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/kule-medication" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage" />
+      <constraint>
+        <key value="kuleprescribing-1" />
+        <severity value="error" />
+        <human value="Dosage must include a freetext if no structured dosage is used" />
+        <xpath value="not(exists(f:text)) or not(exists(f:timing))" />
+      </constraint>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <slicing>
+        <discriminator value="url" />
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <name value="calculationBasis" />
+      <definition value="To specify what forms the basis for calculating the dose (weight, age, body surface, other)." />
+      <alias value="calculationBasis" />
+      <alias value="DoseresEtter" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/calculation-basis" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.DoseresEtter" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <name value="calculationBasisNote" />
+      <definition value="Comment, other relevant information about dosage." />
+      <alias value="calculationBasisNote" />
+      <alias value="Merknad" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/calculation-basis-note" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.Merknad" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <name value="daysAdministeredAmount" />
+      <definition value="Number of days a drug is to be used." />
+      <alias value="daysAdministeredAmount" />
+      <alias value="DagerPa" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/days-administered-amount" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <name value="daysNotAdministeredAmount" />
+      <definition value="Number of days a drug is NOT to be used. This element is always in combination with DagerPa." />
+      <alias value="daysNotAdministeredAmount" />
+      <alias value="DagerAv" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/days-not-administered-amount" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.extension" />
+      <name value="shortDosageText" />
+      <alias value="shortDosageText" />
+      <alias value="Kortdose" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/short-dosage-text" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Kortdose" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.text" />
+      <alias value="Merknad" />
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.Merknad" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing" />
+      <requirements value=" " />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.extension" />
+      <slicing>
+        <discriminator value="url" />
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.extension" />
+      <name value="administerAtSpecificTime" />
+      <definition value="Medication must be given/taken at exact times." />
+      <alias value="administerAtSpecificTime" />
+      <alias value="GisEksakt" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/timing-exact" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.GisEksakt" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.extension" />
+      <name value="extension" />
+      <definition value="Number of units of time that must pass between each time the drug is given/taken." />
+      <alias value="administrationInterval" />
+      <alias value="Intervall" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/timing-interval" />
+      </type>
+      <mustSupport value="true" />
+      <binding>
+        <strength value="required" />
+        <description value="Dette kodeverket inneholder benevning for tidsenheter. Skal benyttes for datatypen PQ når enhet skal være tidsenhet (OID=9088)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/91336a25-1f89-4f12-a185-08a6d06a1af5" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Dose.Intervall" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.repeat" />
+      <comments value=" " />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.repeat.extension" />
+      <slicing>
+        <discriminator value="url" />
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.repeat.extension" />
+      <name value="specificTime" />
+      <definition value="Exact time of day medication must be taken at." />
+      <alias value="specificTime" />
+      <alias value="Klokkeslett" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/time-of-day" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Klokkeslett" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.repeat.extension" />
+      <name value="timePeriod" />
+      <definition value="Time period of the day the drug should be taken at (ex.: morning, noon, afternoon, etc)." />
+      <comments value="Timing.repeat.when is not used as the binding is of strength &quot;required&quot; and is semantically incompatible with OID 8325 from volven.no" />
+      <alias value="timePeriod" />
+      <alias value="Tidsomrade" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/timeperiod" />
+      </type>
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Tidsomrade" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.timing.repeat.extension" />
+      <name value="dayOfWeek" />
+      <alias value="whichWeekdays" />
+      <alias value="FasteUkedager" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/mp9-day-of-week" />
+      </type>
+      <mustSupport value="true" />
+      <binding>
+        <strength value="required" />
+        <description value="Days of the week" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.9.5.4--2015-04-01T00:00:00" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.FastDose.FasteUkedager" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.asNeeded[x]" />
+      <requirements value="Not used to align with DIPS - see drugUseType extension instead." />
+      <max value="0" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.site[x]" />
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.route" />
+      <alias value="Administrasjonsvei" />
+      <mustSupport value="true" />
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.typeLegemiddel.AdministreringLegemiddel.Administrasjonsvei" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.route.coding" />
+      <binding>
+        <strength value="required" />
+        <description value="Administrasjonsvei (OID=7477)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/7ab290d7-7e42-4ec2-a693-75440b0ea038" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.route.text" />
+      <max value="0" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.quantityQuantity" />
+      <name value="SimpleQuantity" />
+      <type>
+        <code value="Quantity" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/SimpleQuantity" />
+      </type>
+      <mustSupport value="true" />
+      <binding>
+        <strength value="required" />
+        <description value="Enhet som skal inngå i doseringstekst som sendes i M1 og inngår på apotek-etiketten. Kodeverk til bruk i M30 fra versjon 2.4, og i M1 (OID=7480)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/7b326ba1-4fae-406f-a50a-35de49e172b1" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x]" />
+      <slicing>
+        <discriminator value="@type" />
+        <rules value="openAtEnd" />
+      </slicing>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x]" />
+      <name value="ratio" />
+      <type>
+        <code value="Ratio" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x].numerator" />
+      <alias value="Volum" />
+      <binding>
+        <strength value="required" />
+        <description value="Dette kodeverket inneholder benevning for legemidlers styrke Skal benyttes for datatypen PQ når enhet skal være legemidlers styrke. Kodeverket oppdateres kun for verdier som inngår i nyeste versjon av FEST (OID=9090)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/7a86c026-005b-489c-86d5-c68dcf7c08c9" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x].denominator" />
+      <alias value="Tidsenhet" />
+      <binding>
+        <strength value="required" />
+        <description value="Dette kodeverket inneholder benevning for tidsenheter. Skal benyttes for datatypen PQ når enhet skal være tidsenhet (OID=9088)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/91336a25-1f89-4f12-a185-08a6d06a1af5" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Tidsenhet" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x]" />
+      <name value="range" />
+      <type>
+        <code value="Range" />
+      </type>
+      <mustSupport value="true" />
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x].low" />
+      <name value="SimpleQuantity" />
+      <alias value="Volum" />
+      <binding>
+        <strength value="required" />
+        <description value="Dette kodeverket inneholder benevning for legemidlers styrke Skal benyttes for datatypen PQ når enhet skal være legemidlers styrke. Kodeverket oppdateres kun for verdier som inngår i nyeste versjon av FEST (OID=9090)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/7a86c026-005b-489c-86d5-c68dcf7c08c9" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
+      </mapping>
+    </element>
+    <element>
+      <path value="MedicationStatement.dosage.rate[x].high" />
+      <name value="SimpleQuantity" />
+      <alias value="Volum" />
+      <binding>
+        <strength value="required" />
+        <description value="Dette kodeverket inneholder benevning for legemidlers styrke Skal benyttes for datatypen PQ når enhet skal være legemidlers styrke. Kodeverket oppdateres kun for verdier som inngår i nyeste versjon av FEST (OID=9090)." />
+        <valueSetReference>
+          <reference value="https://simplifier.net/api/fhir/ValueSet/7a86c026-005b-489c-86d5-c68dcf7c08c9" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="norway-kule-resept" />
+        <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Vadim/MedicationStatement-prescribing.structuredefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Vadim/MedicationStatement-prescribing.structuredefinition.xml
@@ -1,20 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="kule-prescribing" />
+  <id value="ms-prescribing" />
   <meta>
     <lastUpdated value="2017-03-13T11:39:46.369+01:00" />
   </meta>
   <text>
     <status value="generated" /><div xmlns="http://www.w3.org/1999/xhtml">
-  <p>A profile on MedicationStatement describing a prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard.</p>
+  <p>--- SNIP ---</p>
 </div></text>
-  <url value="http://hl7.no/fhir/StructureDefinition/kule-prescribing" />
-  <name value="KULE Prescribing" />
+  <url value="http://example.org/fhir/StructureDefinition/TestMedicationStatement-prescribing" />
+  <name value="Test MedicationStatement prescribing" />
   <status value="draft" />
   <experimental value="false" />
-  <publisher value="HL7 Norge" />
+  <publisher value="Test" />
   <date value="2017-01-27T13:11:14.8692835+01:00" />
-  <description value="A prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard." />
   <kind value="resource" />
   <constrainedType value="MedicationStatement" />
   <abstract value="false" />
@@ -22,10 +21,9 @@
   <differential>
     <element>
       <path value="MedicationStatement" />
-      <short value="KULE Prescribing profile." />
-      <definition value="A prescription as defined by KULE Helse Vest Norwegian project, based on the national standard M1 eResept standard." />
+      <short value="Prescribing profile." />
       <constraint>
-        <key value="kuleprescribing" />
+        <key value="ms-prescribing" />
         <severity value="error" />
         <human value="Reason not taken must be filled if wasNotTaken is true" />
         <xpath value="f:wasNotTaken/@value=false() or exists(f:wasNotTaken)" />
@@ -52,7 +50,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.Forskrivningsdato" />
       </mapping>
     </element>
@@ -74,7 +72,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Resept.Forskrivning.Bruk" />
       </mapping>
     </element>
@@ -96,11 +94,11 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.Instituert.Helseperson" />
       </mapping>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.Instituert.Organisasjon" />
       </mapping>
     </element>
@@ -155,7 +153,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Bruksomrade" />
       </mapping>
     </element>
@@ -171,7 +169,7 @@
       <definition value="Time when the dosage starts." />
       <alias value="Starttidspunkt" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Starttidspunkt" />
       </mapping>
     </element>
@@ -180,7 +178,7 @@
       <definition value="Time when the dosage ends." />
       <alias value="Sluttidspunkt" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Sluttidspunkt" />
       </mapping>
     </element>
@@ -191,7 +189,7 @@
       <alias value="Merknad" />
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.EkspAnm.Merknad" />
       </mapping>
     </element>
@@ -199,14 +197,14 @@
       <path value="MedicationStatement.medicationReference" />
       <type>
         <code value="Reference" />
-        <profile value="http://hl7.no/fhir/StructureDefinition/kule-medication" />
+        <profile value="http://hl7.no/fhir/StructureDefinition/ms-medication" />
       </type>
       <mustSupport value="true" />
     </element>
     <element>
       <path value="MedicationStatement.dosage" />
       <constraint>
-        <key value="kuleprescribing-1" />
+        <key value="ms-prescribing-1" />
         <severity value="error" />
         <human value="Dosage must include a freetext if no structured dosage is used" />
         <xpath value="not(exists(f:text)) or not(exists(f:timing))" />
@@ -233,7 +231,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.DoseresEtter" />
       </mapping>
     </element>
@@ -250,7 +248,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.Merknad" />
       </mapping>
     </element>
@@ -292,7 +290,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Kortdose" />
       </mapping>
     </element>
@@ -301,7 +299,7 @@
       <alias value="Merknad" />
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.Doseringsregel.Merknad" />
       </mapping>
     </element>
@@ -330,7 +328,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.GisEksakt" />
       </mapping>
     </element>
@@ -353,7 +351,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Dose.Intervall" />
       </mapping>
     </element>
@@ -381,7 +379,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Klokkeslett" />
       </mapping>
     </element>
@@ -399,7 +397,7 @@
       </type>
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Tidsomrade" />
       </mapping>
     </element>
@@ -421,7 +419,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.FastDose.FasteUkedager" />
       </mapping>
     </element>
@@ -439,7 +437,7 @@
       <alias value="Administrasjonsvei" />
       <mustSupport value="true" />
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.typeLegemiddel.AdministreringLegemiddel.Administrasjonsvei" />
       </mapping>
     </element>
@@ -500,7 +498,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
       </mapping>
     </element>
@@ -515,7 +513,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Tidsenhet" />
       </mapping>
     </element>
@@ -539,7 +537,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
       </mapping>
     </element>
@@ -555,7 +553,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="norway-kule-resept" />
+        <identity value="ms-resept-map" />
         <map value="Resept.ReseptDokLegemiddel.Forskrivning.Dosering.DoseFastTidspunkt.Dose.Infusjonshastighet.Volum" />
       </mapping>
     </element>

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
+using System.Diagnostics;
 
 namespace Hl7.Fhir.Specification.Snapshot
 {
@@ -66,7 +67,6 @@ namespace Hl7.Fhir.Specification.Snapshot
                     {
                         throw Error.InvalidOperation($"Invalid operation in snapshot generator. Path cannot be changed from '{snap.Path}' to '{diff.Path}', since the type is sliced to '{diff.Type.First().Code}'");
                     }
-
                     snap.PathElement = mergePrimitiveAttribute(snap.PathElement, diff.PathElement);
                 }
 
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // representation cannot be overridden
 
                 snap.NameElement = mergePrimitiveAttribute(snap.NameElement, diff.NameElement);
-            
+
                 // Codes are cumulative based on the code value
                 snap.Code = mergeCollection(snap.Code, diff.Code, (a, b) => a.Code == b.Code);
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorOutcome.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorOutcome.cs
@@ -99,6 +99,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         // "Differential has a constraint on a choice element '{0}', but does so without using a type slice"
         // Differential specifies a constraint on a child element of a choice type element
         // This is not allowed if an element supports multiple element types; must use slicing!
+
         public static readonly Issue PROFILE_ELEMENTDEF_INVALID_CHOICE_CONSTRAINT = Issue.Create(10000, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
 
         void addIssueInvalidChoiceConstraint(ElementDefinition elementDef) { addIssue(CreateIssueInvalidChoiceConstraint(elementDef)); }


### PR DESCRIPTION
- Fix merging of renamed choice type elements (e.g. base = value[x], diff = valueQuantity)
- prevent invalid warning about choice type constraints
In some circumstances, the Snapshot Generator would incorrectly consider certain type constraints on a choice type element to be invalid and emit an operation outcome issue. The generator now tries to process all the existing type constraints in diff without any validation. Caller is responsible for validating the actual constraints.
- never inherit name from root element (e.g. SimpleQuantity)