### PR TITLE
Fix for delete returning a status code of 200 being treated as unexpected

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -336,7 +336,7 @@ namespace Hl7.Fhir.Rest
             var id = verifyResourceIdentity(location, needId: true, needVid: false);
             var tx = new TransactionBuilder(Endpoint).Delete(id.ResourceType, id.Id).ToBundle();
 
-            execute<Resource>(tx, HttpStatusCode.NoContent);
+            execute<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent });
 
             return;
         }
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Rest
             if (condition == null) throw Error.ArgumentNull(nameof(condition));
 
             var tx = new TransactionBuilder(Endpoint).Delete(resourceType, condition).ToBundle();
-            execute<Resource>(tx, HttpStatusCode.NoContent);
+            execute<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent });
 
             return;
         }


### PR DESCRIPTION
STU3 is more clear that HTTP DELETE can return status code 200 - see http://hl7.org/fhir/http.html#delete

Deletes are currently failing for me on the HAPI 2.4 CLI test server with a FhirOperationException: 'Operation concluded successfully, but the return status 200 was unexpected'.