### PR TITLE
Mark types as serializable to enable Orleans serialization of a StructureDefinition

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Base.cs
+++ b/src/Hl7.Fhir.Core/Model/Base.cs
@@ -40,6 +40,9 @@ using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
+#if NET45
+    [Serializable]
+#endif
     [InvokeIValidatableObject]
     [System.Runtime.Serialization.DataContract]
     public abstract class Base : Hl7.Fhir.Validation.IValidatableObject, IDeepCopyable, IDeepComparable, IAnnotated, IAnnotatable

--- a/src/Hl7.Fhir.Core/Model/Code.cs
+++ b/src/Hl7.Fhir.Core/Model/Code.cs
@@ -43,6 +43,9 @@ using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
+#if NET45
+    [Serializable]
+#endif
     [System.Diagnostics.DebuggerDisplay(@"\{{Value}}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
     public partial class Code : IStringValue
     {
@@ -52,6 +55,9 @@ namespace Hl7.Fhir.Model
         }
     }
 
+#if NET45
+    [Serializable]
+#endif
     [FhirType("codeOfT")]
     [DataContract]
     [System.Diagnostics.DebuggerDisplay(@"\{{Value}}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

--- a/src/Hl7.Fhir.Core/Model/Element.cs
+++ b/src/Hl7.Fhir.Core/Model/Element.cs
@@ -43,6 +43,9 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Base for all elements
     /// </summary>
+#if NET45
+    [Serializable]
+#endif
     [DataContract]
     public abstract partial class Element : Base, IExtendable
     {

--- a/src/Hl7.Fhir.Core/Model/Extension.cs
+++ b/src/Hl7.Fhir.Core/Model/Extension.cs
@@ -41,6 +41,9 @@ using Hl7.Fhir.Utility;
 //
 namespace Hl7.Fhir.Model
 {
+#if NET45
+    [Serializable]
+#endif
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value} Url={_Url}}")]
     [FhirType("Extension")]
     [DataContract]

--- a/src/Hl7.Fhir.Core/Model/FhirString.cs
+++ b/src/Hl7.Fhir.Core/Model/FhirString.cs
@@ -38,6 +38,9 @@ using Hl7.Fhir.Model;
 
 namespace Hl7.Fhir.Model
 {
+#if NET45
+    [Serializable]
+#endif
     [System.Diagnostics.DebuggerDisplay(@"{Value}")]
     public partial class FhirString : IStringValue
     {

--- a/src/Hl7.Fhir.Core/Model/Primitive.cs
+++ b/src/Hl7.Fhir.Core/Model/Primitive.cs
@@ -12,6 +12,9 @@ using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
+#if NET45
+    [Serializable]
+#endif
     public abstract class Primitive : Element
     {
         [NotMapped]
@@ -66,6 +69,9 @@ namespace Hl7.Fhir.Model
         }
     }
 
+#if NET45
+    [Serializable]
+#endif
     public abstract class Primitive<T> : Primitive
     {
         // [WMR 20160615] Cannot provide common generic Value property, as subclasses differ in their implementation

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorAnnotations.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorAnnotations.cs
@@ -21,6 +21,9 @@ namespace Hl7.Fhir.Specification.Snapshot
         #region Annotation: Created By Snapshot Generator
 
         /// <summary>Annotation to mark a generated element, so we can prevent duplicate re-generation.</summary>
+#if NET45
+        [Serializable]
+#endif
         sealed class CreatedBySnapshotGeneratorAnnotation
         {
             public DateTime Created { get; }
@@ -43,6 +46,9 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// Custom annotation for elements and properties in the <see cref="StructureDefinition.SnapshotComponent"/>
         /// that are constrained by the <see cref="StructureDefinition.DifferentialComponent"/>.
         /// </summary>
+#if NET45
+        [Serializable]
+#endif
         sealed class ConstrainedByDiffAnnotation
         {
             //
@@ -103,6 +109,9 @@ namespace Hl7.Fhir.Specification.Snapshot
         #region Annotation: Snapshot ElementDefinition
 
         /// <summary>For annotating a differential element definition with a reference to the associated generated snapshot element definition.</summary>
+#if NET45
+        [Serializable]
+#endif
         sealed class SnapshotElementDefinitionAnnotation
         {
             /// <summary>


### PR DESCRIPTION
I added the serializable attribute on some Fhir.Model classes that are required by the Orleans framework in order to send a StructureDefinition serialized to clients