### PR TITLE
fix: moveNext() would not reset index

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Hl7.FhirPath.Expressions;
 using Hl7.Fhir.ElementModel;
 using Hl7.FhirPath;
+using System.IO;
 
 namespace Hl7.Fhir
 {
@@ -176,6 +177,23 @@ namespace Hl7.Fhir
                 Assert.Fail();
             }           
         }
+
+        [TestMethod]
+        public void IncorrectPathInTwoSuccessiveRepeatingMembers()
+        {
+            var xml = File.ReadAllText(@"TestData\issue-444-testdata.xml");
+            var cs = (new FhirXmlParser()).Parse<CapabilityStatement>(xml);
+            var nav = new PocoNavigator(cs);
+
+            nav.MoveToFirstChild();
+
+            Assert.IsTrue(nav.MoveToNext("format"));
+            nav.MoveToNext(); // format[1] again
+            nav.MoveToNext();   // rest[0]
+            
+            Assert.IsTrue(nav.Location.Contains("CapabilityStatement.rest[0]"));
+        }
+
     }
 
 }

--- a/src/Hl7.Fhir.Core.Tests/TestData/issue-444-testdata.xml
+++ b/src/Hl7.Fhir.Core.Tests/TestData/issue-444-testdata.xml
@@ -1,0 +1,54 @@
+﻿<CapabilityStatement xmlns="http://hl7.org/fhir">
+  <id value="ImoFhirTerminologyServer" />
+  <name value="IMO FHIR Terminology Server" />
+  <status value="draft" />
+  <date value="2017-10-17" />
+  <publisher value="Intelligent Medical Objects" />
+  <contact>
+    <name value="Intelligent Medical Objects" />
+    <telecom>
+      <system value="url" />
+      <value value="http://www.e-imo.com" />
+    </telecom>
+  </contact>
+  <description value="Conformance statement for the IMO FHIR Terminology Server" />
+  <kind value="capability" />
+  <fhirVersion value="3.0.1" />
+  <acceptUnknown value="no" />
+  <format value="xml" />
+  <format value="json" />
+  <rest>
+    <mode value="server" />
+    <documentation value="IMO FHIR Terminology Server" />
+    <resource>
+      <type value="ValueSet" />
+      <profile>
+        <reference value="http://hl7.org/fhir/StructureDefinition/ValueSet" />
+      </profile>
+      <interaction>
+        <code value="read" />
+        <documentation value="Read allows clients to get the logical definitions of the value sets" />
+      </interaction>
+      <interaction>
+        <code value="search-type" />
+        <documentation value="Search allows clients to find value sets on the server" />
+      </interaction>
+      <searchParam>
+        <name value="identifier" />
+        <definition value="http://hl7.org/fhir/SearchParameter/ValueSet-identifier" />
+        <type value="token" />
+      </searchParam>
+      <searchParam>
+        <name value="title" />
+        <definition value="http://hl7.org/fhir/SearchParameter/ValueSet-title" />
+        <type value="string" />
+      </searchParam>
+    </resource>
+    <operation>
+      <name value="expand" />
+      <definition>
+        <reference value="http://hl7.org/fhir/OperationDefinition/ValueSet-expand" />
+      </definition>
+    </operation>
+  </rest>
+</CapabilityStatement>

--- a/src/Hl7.Fhir.Core/ElementModel/PocoElementNavigator.cs
+++ b/src/Hl7.Fhir.Core/ElementModel/PocoElementNavigator.cs
@@ -10,9 +10,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Utility;
 using Hl7.Fhir.Serialization;
-using System.Collections;
 
 namespace Hl7.Fhir.ElementModel
 {
@@ -20,7 +18,7 @@ namespace Hl7.Fhir.ElementModel
     {
         private Base _parent;
 
-        private int _arrayIndex; // this is only for the ShortPath implementation eg Patient.Name[1].Family (its the 1 here)
+        private int? _arrayIndex; // this is only for the ShortPath implementation eg Patient.Name[1].Family (its the 1 here)
         private int _index;
         private IList<ElementValue> _children;
 
@@ -30,7 +28,7 @@ namespace Hl7.Fhir.ElementModel
             // The root is the special case, we start with a "collection" of children where the parent is the only element
             _parent = null;
             _index = 0;
-            _arrayIndex = -1;
+            _arrayIndex = null;
             _children = new List<ElementValue>() { new ElementValue(parent.TypeName, false, parent) };
         }
 
@@ -62,7 +60,7 @@ namespace Hl7.Fhir.ElementModel
 
             // Reset everything, next() will initialize the values for the first "child"
             _index = -1;
-            _arrayIndex = -1;
+            _arrayIndex = null;
 
             return true;
         }
@@ -76,17 +74,22 @@ namespace Hl7.Fhir.ElementModel
 
             while (scan + 1 < _children.Count)
             {
+                var oldElementName = scan >= 0 ? _children[scan].ElementName : null;
+
                 scan += 1;
                 var scanProp = _children[scan];
+
+                if (oldElementName != scanProp.ElementName)
+                    _arrayIndex = null;
 
                 if (name == null || scanProp.ElementName == name)
                 {
                     _index = scan;
 
                     if (!scanProp.IsCollectionMember)
-                        _arrayIndex = -1;
+                        _arrayIndex = null;
                     else
-                        _arrayIndex += 1;
+                        _arrayIndex = _arrayIndex == null ? 0 : _arrayIndex + 1;
 
                     return true;
                 }
@@ -101,7 +104,7 @@ namespace Hl7.Fhir.ElementModel
 
         public bool AtCollection => Current.IsCollectionMember;
 
-        public int ArrayIndex => AtCollection ? _arrayIndex : 0;
+        public int ArrayIndex => AtCollection ? _arrayIndex.Value : 0;
 
         /// <summary>
         /// This is only needed for search data extraction (and debugging)


### PR DESCRIPTION
The implementation of MoveNext() on the PocoNavigator was incorrect, generating incorrect Locations. This happened whenever two consecutive repeating properties were encountered, the index of the path indexer (Bla.blie[x].bla[y]...) was counting the number of times the same element name was encountered, but this was not reset when a new element was encountered.  