### PR TITLE
fix: Validator no longer produces a warning about unknown references …

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -318,12 +318,12 @@ namespace Hl7.Fhir.Specification.Tests
 
             Patient p = new Patient();
             p.Active = true;
-            p.ManagingOrganization = new ResourceReference("http://isure.cannot.be.found.nl/fhir/Patient/1");
+            p.ManagingOrganization = new ResourceReference("http://reference.cannot.be.found.nl/fhir/Patient/1");
 
             var result = validator.Validate(p);
             Assert.True(result.Success);
             Assert.Equal(1, result.Warnings);
-            Assert.Contains("Cannot resolve reference http://isure.cannot.be.found.nl/fhir/Patient/1", result.Issue[0].ToString());
+            Assert.Contains("Cannot resolve reference http://reference.cannot.be.found.nl/fhir/Patient/1", result.Issue[0].ToString());
 
             validator.Settings.ResolveExteralReferences = false;
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -312,6 +312,27 @@ namespace Hl7.Fhir.Specification.Tests
 
 
         [Fact]
+        public void DoNotFollowRefsSuppressesWarning()
+        {
+            var validator = new Validator(new ValidationSettings { ResourceResolver = _source, ResolveExteralReferences = true });
+
+            Patient p = new Patient();
+            p.Active = true;
+            p.ManagingOrganization = new ResourceReference("http://isure.cannot.be.found.nl/fhir/Patient/1");
+
+            var result = validator.Validate(p);
+            Assert.True(result.Success);
+            Assert.Equal(1, result.Warnings);
+            Assert.Contains("Cannot resolve reference http://isure.cannot.be.found.nl/fhir/Patient/1", result.Issue[0].ToString());
+
+            validator.Settings.ResolveExteralReferences = false;
+
+            result = validator.Validate(p);
+            Assert.True(result.Success);
+            Assert.Equal(0, result.Warnings);
+        }
+
+        [Fact]
         public void ValidateOverNameRef()
         {
             var questionnaireXml = File.ReadAllText("TestData\\validation\\questionnaire-sdc-profile-example-cap.xml");


### PR DESCRIPTION
…if ResolveReferences is disabled in settings