### PR TITLE
Feature #497 - IConformanceSource.ListSummaries returns ReadOnlyCollection

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Source.Summary;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -53,7 +54,7 @@ namespace Hl7.Fhir.Specification.Tests
         public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?))
             => _resources.Select(g => g.Key);
 
-        public IReadOnlyList<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
+        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
 
         #endregion
     }

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
@@ -53,7 +53,7 @@ namespace Hl7.Fhir.Specification.Tests
         public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?))
             => _resources.Select(g => g.Key);
 
-        public IEnumerable<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
+        public IReadOnlyList<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
 
         #endregion
     }

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
@@ -14,7 +14,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         public TimingSource(IConformanceSource source) { _source = source; }
 
-        public IEnumerable<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
+        public IReadOnlyList<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
 
         public IEnumerable<ConceptMap> FindConceptMaps(string sourceUri = null, string targetUri = null)
             => measureDuration(() => _source.FindConceptMaps(sourceUri, targetUri));

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Source.Summary;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -14,7 +15,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         public TimingSource(IConformanceSource source) { _source = source; }
 
-        public IReadOnlyList<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
+        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
 
         public IEnumerable<ConceptMap> FindConceptMaps(string sourceUri = null, string targetUri = null)
             => measureDuration(() => _source.FindConceptMaps(sourceUri, targetUri));

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -81,7 +81,7 @@ namespace Hl7.Fhir.Specification.Tests
             File.Copy(Path.Combine(dir, file), Path.Combine(outputDir, file));
         }
 
-        private string prepareExampleDirectory(out int numFiles)
+        private (string path, int numFiles) prepareExampleDirectory()
         {
             var zipFile = Path.Combine(Directory.GetCurrentDirectory(), "specification.zip");
             var zip = new ZipCacher(zipFile);
@@ -103,18 +103,19 @@ namespace Hl7.Fhir.Specification.Tests
             copy(@"TestData", "TestPatient.json", subPath);
 
             // If you add or remove files, please correct the numFiles here below
-            numFiles = 8 - 1;   // 8 files - 1 binary (which should be ignored)
+            var numFiles = 8 - 1;   // 8 files - 1 binary (which should be ignored)
 
-            return testPath;
+            return (testPath, numFiles);
         }
 
 
         private string _testPath;
+        private int _numFiles;
 
         [TestInitialize]
         public void SetupExampleDir()
         {
-            _testPath = prepareExampleDirectory(out int numFiles);
+            (_testPath, _numFiles) = prepareExampleDirectory();
         }
 
         [TestMethod]
@@ -193,7 +194,8 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void ReadsSubdirectories()
         {
-            var testPath = prepareExampleDirectory(out int numFiles);
+            // var (testPath, numFiles) = prepareExampleDirectory();
+            var (testPath, numFiles) = (_testPath, _numFiles);
             var fa = new DirectorySource(testPath, new DirectorySourceSettings() {  IncludeSubDirectories = true });
             var names = fa.ListArtifactNames();
 
@@ -273,7 +275,8 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod, TestCategory("IntegrationTest")]
         public void TestAccessPermissions()
         {
-            var testPath = prepareExampleDirectory(out int numFiles);
+            // var (testPath, numFiles) = prepareExampleDirectory();
+            var (testPath, numFiles) = (_testPath, _numFiles);
 
             // Additional temporary folder without read permissions
             var subPath2 = Path.Combine(testPath, "sub2");

--- a/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
@@ -35,7 +35,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
-
+using System.Collections.ObjectModel;
 
 namespace Hl7.Fhir.Specification.Source
 {
@@ -446,7 +446,7 @@ namespace Hl7.Fhir.Specification.Source
         #region IConformanceSource
 
         /// <summary>Returns a list of summary information for all FHIR artifacts in the specified content directory.</summary>
-        public IReadOnlyList<ArtifactSummary> ListSummaries() => GetSummaries().AsReadOnly();
+        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => GetSummaries().AsReadOnly();
 
         /// <summary>List all resource uris, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
@@ -446,8 +446,7 @@ namespace Hl7.Fhir.Specification.Source
         #region IConformanceSource
 
         /// <summary>Returns a list of summary information for all FHIR artifacts in the specified content directory.</summary>
-        public IEnumerable<ArtifactSummary> ListSummaries() 
-            => GetSummaries().Select(s => s); // Prevent caller from modifying internal list
+        public IReadOnlyList<ArtifactSummary> ListSummaries() => GetSummaries().AsReadOnly();
 
         /// <summary>List all resource uris, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source.Summary;
+using System.Collections.ObjectModel;
 
 namespace Hl7.Fhir.Specification.Source
 {
@@ -17,7 +18,10 @@ namespace Hl7.Fhir.Specification.Source
     public interface IConformanceSource : IResourceResolver
     {
         /// <summary>Returns a list of summary information for all the FHIR artifacts provided by the source.</summary>
-        IReadOnlyList<ArtifactSummary> ListSummaries();
+        ReadOnlyCollection<ArtifactSummary> ListSummaries();
+
+        // [WMR 20171204] We could convert the following members to extension methods (ConformanceSourceExtensions)
+        // Breaking change, but decreases interface implementer burden
 
         /// <summary>List all resource uris for the resources managed by the source, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
@@ -17,7 +17,7 @@ namespace Hl7.Fhir.Specification.Source
     public interface IConformanceSource : IResourceResolver
     {
         /// <summary>Returns a list of summary information for all the FHIR artifacts provided by the source.</summary>
-        IEnumerable<ArtifactSummary> ListSummaries();
+        IReadOnlyList<ArtifactSummary> ListSummaries();
 
         /// <summary>List all resource uris for the resources managed by the source, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
@@ -126,7 +126,7 @@ namespace Hl7.Fhir.Specification.Source
         #region IConformanceSource
 
         /// <summary>Returns a list of summary information for all the FHIR artifacts in the ZIP archive.</summary>
-        public IEnumerable<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
+        public IReadOnlyList<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
 
         /// <summary>List all resource uris, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>

--- a/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Specification.Source.Summary;
 using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -126,7 +127,7 @@ namespace Hl7.Fhir.Specification.Source
         #region IConformanceSource
 
         /// <summary>Returns a list of summary information for all the FHIR artifacts in the ZIP archive.</summary>
-        public IReadOnlyList<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
+        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
 
         /// <summary>List all resource uris, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>


### PR DESCRIPTION
No use casting return value to IReadOnlyList<T>, better to return the original concrete type.