### PR TITLE
Fix null reference exception in ComplexTypeWriter.

### DIFF
--- a/src/Hl7.Fhir.Core/Serialization/ComplexTypeWriter.cs
+++ b/src/Hl7.Fhir.Core/Serialization/ComplexTypeWriter.cs
@@ -107,7 +107,7 @@ namespace Hl7.Fhir.Serialization
             if (instance is IList)
                 instance = ((IList)instance)[0];
 
-            if (!prop.IsPrimitive && prop.Choice != ChoiceType.ResourceChoice)
+            if (instance != null && !prop.IsPrimitive && prop.Choice != ChoiceType.ResourceChoice)
             {
                 var mapping = _inspector.ImportType(instance.GetType());
                 return mapping.HasPrimitiveValueMember;


### PR DESCRIPTION
Hi Ewout,
by adding this null check, the DispatchingWriter will throw an error in it's Serialize method:
"The FHIR serialization does not support arrays with empty (null) elements"
