### PR TITLE
fix issue #544, DateTimeOffset cannot convert to DateTime directly, s…

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/ConversionTest.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ConversionTest.cs
@@ -108,7 +108,13 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.AreEqual(new DateTimeOffset(2011,3,4,16,45,33, TimeSpan.Zero),ins5.Value);
         }
 
-        [TestMethod]
+	    [TestMethod]
+	    public void TestStringToDateTime()
+	    {
+		    Assert.AreEqual(PrimitiveTypeConverter.ConvertTo<DateTime>("1976-12-12"), new DateTime(1976, 12, 12));
+	    }
+
+	    [TestMethod]
         public void TestStringToUri()
         {
             var result = PrimitiveTypeConverter.ConvertTo<Uri>("http://www.nu.nl/test");

--- a/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
+++ b/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
@@ -108,7 +108,7 @@ namespace Hl7.Fhir.Serialization
             if(typeof(Char) == to)
                 return XmlConvert.ToChar(value);        // Not used in FHIR serialization
             if(typeof(DateTime) == to)
-                return XmlConvert.ToDateTimeOffset(value); // TODO: should handle FHIR's "instant" datatype
+                return XmlConvert.ToDateTimeOffset(value).DateTime; // TODO: should handle FHIR's "instant" datatype
             if(typeof(Decimal) == to)
                 return XmlConvert.ToDecimal(value);
             if(typeof(Double) == to)


### PR DESCRIPTION
This commit is to fix #544 . The bug was due to an invalid cast from DateTimeOffset to DateTime. It should use DateTimeOffset.DateTime to convert a DateTimeOffset to a DateTime.