### PR TITLE
ISummarySource & Serialize to DOM

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -6,18 +6,17 @@
  * available at https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/master/LICENSE
  */
 
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
-using System.Text;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Globalization;
 using Hl7.Fhir.Utility;
 using Hl7.Fhir.Introspection;
-using System.Runtime.Serialization;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -31,7 +30,7 @@ namespace Hl7.Fhir.Tests.Serialization
         [TestMethod]
         public void SerializeMetaXml()
         {
-            var xml = new FhirXmlSerializer().SerializeToString(metaPoco,root:"meta");
+            var xml = new FhirXmlSerializer().SerializeToString(metaPoco, root: "meta");
             Assert.AreEqual(metaXml, xml);
         }
 
@@ -47,7 +46,7 @@ namespace Hl7.Fhir.Tests.Serialization
         public void ParseMetaXml()
         {
             var poco = (Meta)(new FhirXmlParser().Parse(metaXml, typeof(Meta)));
-            var xml = new FhirXmlSerializer().SerializeToString(poco,root:"meta");
+            var xml = new FhirXmlSerializer().SerializeToString(poco, root: "meta");
 
             Assert.IsTrue(poco.IsExactly(metaPoco));
             Assert.AreEqual(metaXml, xml);
@@ -713,5 +712,117 @@ namespace Hl7.Fhir.Tests.Serialization
             var json = FhirJsonSerializer.SerializeToString(bundle);
             Assert.IsNotNull(json);
         }
+
+// #if NET45
+        // [WMR 20180409] NEW: Serialize to XmlDocument
+        [TestMethod]
+        public void TestSerializeToXmlDocument()
+        {
+            var patientOne = new Patient
+            {
+
+                Id = "patient-one",
+                Text = new Narrative { Status = Narrative.NarrativeStatus.Generated, Div = "<div>A great blues player</div>" },
+                Meta = new Meta { ElementId = "eric-clapton", VersionId = "1234" },
+
+                Name = new List<HumanName> { new HumanName { Family = "Clapton", Use = HumanName.NameUse.Official } },
+
+                Active = true,
+                BirthDate = "2015-07-09",
+                Gender = AdministrativeGender.Male
+            };
+
+            var doc = FhirXmlSerializer.SerializeToDocument(patientOne);
+            Assert.IsNotNull(doc);
+            Assert.AreEqual("#document", doc.Name);
+            Assert.IsTrue(doc.HasChildNodes);
+            Assert.AreEqual(1, doc.ChildNodes.Count);
+
+            var root = doc.FirstChild;
+            Assert.AreEqual("Patient", root.Name);
+            Assert.IsTrue(root.HasChildNodes);
+            Assert.AreEqual(7, root.ChildNodes.Count);
+        }
+// #endif
+
+        // [WMR 20180409] NEW: Serialize to JObject
+        [TestMethod]
+        public void TestSerializeToJsonDocument()
+        {
+            // Note: output order is defined by core resource/datatype definitions!
+
+            var patientOne = new Patient
+            {
+
+                Id = "patient-one",
+                Meta = new Meta { ElementId = "eric-clapton", VersionId = "1234" },
+                Text = new Narrative { Status = Narrative.NarrativeStatus.Generated, Div = "<div>A great blues player</div>" },
+                Active = true,
+                Name = new List<HumanName> { new HumanName { Use = HumanName.NameUse.Official, Family = "Clapton" } },
+                Gender = AdministrativeGender.Male,
+                BirthDate = "2015-07-09",
+            };
+
+            var doc = FhirJsonSerializer.SerializeToDocument(patientOne);
+            Assert.IsNotNull(doc);
+
+            System.Diagnostics.Debug.Print(doc.ToString());
+
+            Assert.AreEqual(8, doc.Count); // Including resourceType
+
+            JToken assertProperty(JToken t, string expectedName)
+            {
+                Assert.AreEqual(JTokenType.Property, t.Type);
+                var p = t as JProperty;
+                Assert.IsNotNull(p);
+                Assert.AreEqual(expectedName, p.Name);
+                return t;
+            }
+
+            JToken assertPrimitiveProperty(JToken t, string expectedName, JTokenType expectedType, object expectedValue)
+            {
+                var p = t as JProperty;
+                Assert.IsNotNull(p);
+                Assert.AreEqual(expectedName, p.Name);
+                Assert.AreEqual(expectedType, p.Value.Type);
+                var v = p.Value as JValue;
+                Assert.IsNotNull(v);
+                Assert.AreEqual(expectedValue, v.Value);
+                return t;
+            }
+
+            JToken assertStringProperty(JToken t, string expectedName, object expectedValue) => assertPrimitiveProperty(t, expectedName, JTokenType.String, expectedValue);
+
+            Assert.AreEqual(JTokenType.Property, doc.First.Type);
+            var token = assertStringProperty(doc.First, "resourceType", "Patient");
+            token = assertStringProperty(token.Next, "id", patientOne.Id);
+
+            token = assertProperty(token.Next, "meta");
+            Assert.IsTrue(token.HasValues);
+            var childToken = assertStringProperty(token.Values().First(), "id", patientOne.Meta.ElementId);
+            childToken = assertStringProperty(childToken.Next, "versionId", patientOne.Meta.VersionId);
+
+            token = assertProperty(token.Next, "text");
+            Assert.IsTrue(token.HasValues);
+            childToken = assertStringProperty(token.Values().First(), "status", patientOne.Text.Status.GetLiteral());
+            childToken = assertStringProperty(childToken.Next, "div", patientOne.Text.Div);
+
+            token = assertPrimitiveProperty(token.Next, "active", JTokenType.Boolean, patientOne.Active);
+
+            token = assertProperty(token.Next, "name");
+            var values = token.First;
+            Assert.IsNotNull(values);
+            Assert.AreEqual(JTokenType.Array, values.Type);
+            childToken = values.First;
+            var grandChildToken = assertStringProperty(childToken.First, "use", patientOne.Name[0].Use.GetLiteral());
+            grandChildToken = assertStringProperty(grandChildToken.Next, "family", patientOne.Name[0].Family);
+
+            token = assertStringProperty(token.Next, "gender", patientOne.Gender.GetLiteral());
+
+            token = assertStringProperty(token.Next, "birthDate", patientOne.BirthDate);
+
+        }
+
     }
+
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirSerializer.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 using System.Xml;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
+using Newtonsoft.Json.Linq;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -79,6 +80,22 @@ namespace Hl7.Fhir.Serialization
             });
         }
 
+#if NET45
+        // [WMR 20180409] NEW
+        // https://github.com/ewoutkramer/fhir-net-api/issues/545
+        public XmlDocument SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string root = null)
+        {
+            return xmlWriterToDocument(xw =>
+            {
+                using (var writer = new XmlFhirWriter(xw))
+                {
+                    Serialize(instance, writer, summary, root);
+                    xw.Flush();
+                }
+            });
+        }
+#endif
+
         // [WMR 20160421] Caller is responsible for disposing writer
         public void Serialize(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False) => Serialize(instance, new XmlFhirWriter(writer), summary);
 
@@ -125,6 +142,26 @@ namespace Hl7.Fhir.Serialization
             }
 
         }
+
+#if NET45
+        // [WMR 20180409] NEW
+        // https://stackoverflow.com/a/1347364
+        private static XmlDocument xmlWriterToDocument(Action<XmlWriter> serializer)
+        {
+            XmlDocument doc = new XmlDocument();
+
+            // using (XmlWriter xw = doc.CreateDocumentFragment().CreateNavigator().AppendChild())
+            using (XmlWriter xw = doc.CreateNavigator().AppendChild())
+            {
+                // [WMR 20160421] serializer action now calls Flush before disposing
+                serializer(xw);
+                // xw.Flush();
+            }
+
+            return doc;
+        }
+#endif
+
     }
 
     public class FhirJsonSerializer : BaseFhirSerializer
@@ -140,7 +177,7 @@ namespace Hl7.Fhir.Serialization
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False)
         {
             // [WMR 20160421] Explicit disposal
-            // return jsonWriterToString(jw => Serialize(instance, new JsonDomFhirWriter(jw), summary, root));
+            // return jsonWriterToString(jw => Serialize(instance, new JsonDomFhirWriter(jw), summary));
             return jsonWriterToString(jw =>
             {
                 using (var writer = new JsonDomFhirWriter(jw))
@@ -154,8 +191,22 @@ namespace Hl7.Fhir.Serialization
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False)
         {
             // [WMR 20160421] Explicit disposal
-            // return jsonWriterToBytes(jw => Serialize(instance, new JsonDomFhirWriter(jw), summary, root));
+            // return jsonWriterToBytes(jw => Serialize(instance, new JsonDomFhirWriter(jw), summary));
             return jsonWriterToBytes(jw =>
+            {
+                using (var writer = new JsonDomFhirWriter(jw))
+                {
+                    Serialize(instance, writer, summary, null);
+                    jw.Flush();
+                }
+            });
+        }
+
+        // [WMR 20180409] NEW
+        // https://github.com/ewoutkramer/fhir-net-api/issues/545
+        public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False)
+        {
+            return jsonWriterToDocument(jw =>
             {
                 using (var writer = new JsonDomFhirWriter(jw))
                 {
@@ -215,8 +266,33 @@ namespace Hl7.Fhir.Serialization
                 return resultBuilder.ToString();
             }
         }
+
+        // [WMR 20180409] NEW
+        // cf. FhirXmlSerializer.xmlWriterToDocument()
+        private static JObject jsonWriterToDocument(Action<JsonWriter> serializer)
+        {
+            // [WMR 20180409] Triggers runtime exception "Can not add Newtonsoft.Json.Linq.JObject to Newtonsoft.Json.Linq.JObject."
+            // JsonDomFhirWriter.WriteEndProperty() => _root.WriteTo(jw) => jw.WriteStartObject() => exception...
+            //var doc = new JObject();
+
+            // JConstructor / JArray works, extract and return first child node
+            var doc = new JArray();
+
+            using (JsonWriter jw = doc.CreateWriter())
+            {
+                // [WMR 20160421] serializer action now calls Flush before disposing
+                serializer(jw);
+                // xw.Flush();
+            }
+
+            //return doc;
+            System.Diagnostics.Debug.Assert(doc.Count == 1);
+            return doc.First as JObject;
+        }
+
     }
 
+    [Obsolete("Obsolete. Instead, create a new FhirXmlSerializer or FhirJsonSerializer instance and call one of the serialization methods.")]
     public static class FhirSerializer
     {
         private static FhirXmlSerializer _xmlSerializer = new FhirXmlSerializer();

--- a/src/Hl7.Fhir.Core/Serialization/JsonDomFhirWriter.cs
+++ b/src/Hl7.Fhir.Core/Serialization/JsonDomFhirWriter.cs
@@ -88,8 +88,10 @@ namespace Hl7.Fhir.Serialization
 
                 _current = parent;
             }
-            else if(_current == _createdRootObject)
+            else if (_current == _createdRootObject)
+            {
                 _root.WriteTo(jw);
+            }
         }
 
         public void WriteStartComplexContent()

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/InMemoryProfileResolver.cs
@@ -54,8 +54,6 @@ namespace Hl7.Fhir.Specification.Tests
         public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?))
             => _resources.Select(g => g.Key);
 
-        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
-
         #endregion
     }
 

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -6232,7 +6232,107 @@ namespace Hl7.Fhir.Specification.Tests
             // 5. Extension: accuracyIndicator
             Assert.IsTrue(nav.MoveToNextSlice());
             Assert.AreEqual("accuracyIndicator", nav.Current.SliceName);
+        }
 
+        // [WMR 20180410] Unit test to investigate issue reported by David McKillop
+        [TestMethod]
+        public void TestAuPatientDerived()
+        {
+            var sd = new StructureDefinition()
+            {
+                Type = FHIRAllTypes.Patient.GetLiteral(),
+                BaseDefinition = @"http://hl7.org.au/fhir/StructureDefinition/au-patient",
+                Name = "AuPatientDerived",
+                Url = "http://example.org/fhir/StructureDefinition/AuPatientDerived",
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>()
+                    {
+                        new ElementDefinition("Patient.deceased[x]")
+                        {
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceased[x]")
+                        {
+                            SliceName = "deceasedBoolean",
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceased[x]")
+                        {
+                            SliceName = "deceasedDateTime",
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceased[x].extension")
+                        {
+                            SliceName = "accuracyIndicator",
+                            MustSupport = true
+                        }
+                    }
+                }
+
+            };
+
+            generateSnapshotAndCompare(sd, out StructureDefinition expanded);
+
+            dumpOutcome(_generator.Outcome);
+            dumpBaseElems(expanded.Snapshot.Element);
+
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+
+            Assert.IsNull(_generator.Outcome);
+        }
+
+        // [WMR 20180410] Cannot handle invalid (!) choice type element renaming within type slice
+        // Exception from ElementMatcher.matchBase - choiceNames.SingleOrDefault()
+        // TODO: Gracefully handle multiple matches, emit issue, use first match
+        [Ignore]
+        [TestMethod]
+        public void TestAuPatientDerived2()
+        {
+            var sd = new StructureDefinition()
+            {
+                Type = FHIRAllTypes.Patient.GetLiteral(),
+                BaseDefinition = @"http://hl7.org.au/fhir/StructureDefinition/au-patient",
+                Name = "AuPatientDerived2",
+                Url = "http://example.org/fhir/StructureDefinition/AuPatientDerived2",
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>()
+                    {
+                        new ElementDefinition("Patient.deceased[x]")
+                        {
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceasedBoolean]")
+                        {
+                            SliceName = "deceasedBoolean",
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceasedDateTime")
+                        {
+                            SliceName = "deceasedDateTime",
+                            MustSupport = true
+                        },
+                        new ElementDefinition("Patient.deceasedDateTime.extension")
+                        {
+                            SliceName = "accuracyIndicator",
+                            MustSupport = true
+                        }
+                    }
+                }
+
+            };
+
+            generateSnapshotAndCompare(sd, out StructureDefinition expanded);
+
+            dumpOutcome(_generator.Outcome);
+            dumpBaseElems(expanded.Snapshot.Element);
+
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+
+            Assert.IsNull(_generator.Outcome);
         }
 
     }

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/TimingSource.cs
@@ -15,8 +15,6 @@ namespace Hl7.Fhir.Specification.Tests
 
         public TimingSource(IConformanceSource source) { _source = source; }
 
-        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
-
         public IEnumerable<ConceptMap> FindConceptMaps(string sourceUri = null, string targetUri = null)
             => measureDuration(() => _source.FindConceptMaps(sourceUri, targetUri));
 

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -156,6 +156,24 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
+        public void ExcludeSubdirectory()
+        {
+            var fa = new DirectorySource(_testPath)
+            {
+                Includes = new[] { "*.json" },
+                IncludeSubDirectories = true
+            };
+
+            var names = fa.ListArtifactNames();
+            Assert.AreEqual(1, names.Count());
+
+            fa.Excludes = new[] { "/sub/" };
+
+            names = fa.ListArtifactNames();
+            Assert.AreEqual(0, names.Count());
+        }
+
+        [TestMethod]
         public void FileSourceSkipsInvalidXml()
         {
             var fa = new DirectorySource(_testPath);

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -174,7 +174,7 @@ namespace Hl7.Fhir.Specification.Tests
             var sd = fa.FindStructureDefinition("http://hl7.org/fhir/StructureDefinition/patient-birthTime");
             Assert.IsNotNull(sd);
 
-            var errors = fa.Errors().ToList();
+            var errors = fa.ListSummaryErrors().ToList();
             Assert.AreEqual(1, errors.Count);
             var error = errors[0];
             Debug.Print($"{error.Origin} : {error.Error.Message}");

--- a/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
@@ -195,66 +195,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        public void GetSomeArtifactsBySummary()
-        {
-            var fa = source;
-
-            var summaries = fa.ListSummaries();
-
-            var summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/v2-0292");
-            Assert.IsNotNull(summary);
-            var vs = summary.LoadResource();
-            Assert.IsTrue(vs is ValueSet);
-            Assert.IsTrue(vs.GetOrigin().EndsWith("v2-tables.xml"));
-
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/administrative-gender");
-            Assert.IsNotNull(summary);
-            vs = summary.LoadResource();
-            Assert.IsNotNull(vs);
-            Assert.IsTrue(vs is ValueSet);
-
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/location-status");
-            Assert.IsNotNull(summary);
-            vs = summary.LoadResource();
-            Assert.IsNotNull(vs);
-            Assert.IsTrue(vs is ValueSet);
-
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Condition");
-            Assert.IsNotNull(summary);
-            var rs = summary.LoadResource();
-            Assert.IsNotNull(rs);
-            Assert.IsTrue(rs is StructureDefinition);
-            Assert.IsTrue(rs.GetOrigin().EndsWith("profiles-resources.xml"));
-
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/ValueSet");
-            Assert.IsNotNull(summary);
-            rs = summary.LoadResource();
-            Assert.IsNotNull(rs);
-            Assert.IsTrue(rs is StructureDefinition);
-
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Money");
-            Assert.IsNotNull(summary);
-            var dt = summary.LoadResource();
-            Assert.IsNotNull(dt);
-            Assert.IsTrue(dt is StructureDefinition);
-
-            // Try to find a core extension
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/valueset-history");
-            Assert.IsNotNull(summary);
-            var ext = summary.LoadResource();
-            Assert.IsNotNull(ext);
-            Assert.IsTrue(ext is StructureDefinition);
-
-            // Try to find an additional US profile (they are distributed with the spec for now)
-            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/cqif-questionnaire");
-            Assert.IsNotNull(summary);
-            var us = summary.LoadResource();
-            Assert.IsNotNull(us);
-            Assert.IsTrue(us is StructureDefinition);
-        }
-
-
-        [TestMethod]
         public void TestFilenameDeDuplication()
         {
             var paths = new List<string> { @"c:\blie\bla.txt", @"c:\bla\bla.txt", @"c:\blie\bla.txt", @"c:\yadi.json",
@@ -460,35 +400,6 @@ namespace Hl7.Fhir.Specification.Tests
                 Debug.WriteLine($"{title} : {(multiThreaded ? "multi" : "single")} threaded, {cnt} resources, duration {sw.ElapsedMilliseconds} ms");
                 Assert.IsTrue(sw.ElapsedMilliseconds < maxDuration);
             }
-        }
-
-        [TestMethod]
-        public void ListSummaries()
-        {
-            var source = new DirectorySource(Path.Combine(DirectorySource.SpecificationDirectory, "TestData", "snapshot-test"),
-                new DirectorySourceSettings { IncludeSubDirectories = true });
-
-            var sd = source.Summaries(ResourceType.StructureDefinition); Assert.IsTrue(sd.Any());
-            var sm = source.Summaries(ResourceType.StructureMap); Assert.IsTrue(sd.Any());
-            var de = source.Summaries(ResourceType.DataElement); Assert.IsFalse(de.Any());
-            var cf = source.Summaries(ResourceType.CapabilityStatement); Assert.IsTrue(cf.Any());
-            var md = source.Summaries(ResourceType.MessageDefinition); Assert.IsFalse(md.Any());
-            var od = source.Summaries(ResourceType.OperationDefinition); Assert.IsTrue(od.Any());
-            var sp = source.Summaries(ResourceType.SearchParameter); Assert.IsFalse(sp.Any());
-            var cd = source.Summaries(ResourceType.CompartmentDefinition); Assert.IsFalse(md.Any());
-            var ig = source.Summaries(ResourceType.ImplementationGuide); Assert.IsFalse(ig.Any());
-
-            var cs = source.Summaries(ResourceType.CodeSystem); Assert.IsFalse(cs.Any());
-            var vs = source.Summaries(ResourceType.ValueSet); Assert.IsTrue(vs.Any());
-            var cm = source.Summaries(ResourceType.ConceptMap); Assert.IsFalse(cm.Any());
-            var ep = source.Summaries(ResourceType.ExpansionProfile); Assert.IsFalse(ep.Any());
-            var ns = source.Summaries(ResourceType.NamingSystem); Assert.IsFalse(ns.Any());
-
-            var all = source.ListSummaries();
-
-            Assert.AreEqual(sd.Count() + sm.Count() + de.Count() + cf.Count() + md.Count() + od.Count() +
-                        sp.Count() + cd.Count() + ig.Count() + cs.Count() + vs.Count() + cm.Count() +
-                        ep.Count() + ns.Count(), all.Count());
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification.Tests/Source/SummarySourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/SummarySourceTests.cs
@@ -1,0 +1,177 @@
+﻿/* 
+ * Copyright (c) 2018, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/master/LICENSE
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Specification.Source.Summary;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+// Use alias to avoid conflict with Hl7.Fhir.Model.Task
+using Tasks = System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    [TestClass]
+    public class SummarySourceTests
+    {
+        [ClassInitialize]
+        public static void SetupSource(TestContext t)
+        {
+            source = ZipSource.CreateValidationSource();
+        }
+
+        static ISummarySource source = null;
+
+
+        [TestMethod]
+        public void GetSomeArtifactsBySummary()
+        {
+            var fa = source;
+
+            var summaries = fa.ListSummaries();
+
+            var summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/v2-0292");
+            Assert.IsNotNull(summary);
+            var vs = summary.LoadResource();
+            Assert.IsTrue(vs is ValueSet);
+            Assert.IsTrue(vs.GetOrigin().EndsWith("v2-tables.xml"));
+
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/administrative-gender");
+            Assert.IsNotNull(summary);
+            vs = summary.LoadResource();
+            Assert.IsNotNull(vs);
+            Assert.IsTrue(vs is ValueSet);
+
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/ValueSet/location-status");
+            Assert.IsNotNull(summary);
+            vs = summary.LoadResource();
+            Assert.IsNotNull(vs);
+            Assert.IsTrue(vs is ValueSet);
+
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Condition");
+            Assert.IsNotNull(summary);
+            var rs = summary.LoadResource();
+            Assert.IsNotNull(rs);
+            Assert.IsTrue(rs is StructureDefinition);
+            Assert.IsTrue(rs.GetOrigin().EndsWith("profiles-resources.xml"));
+
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/ValueSet");
+            Assert.IsNotNull(summary);
+            rs = summary.LoadResource();
+            Assert.IsNotNull(rs);
+            Assert.IsTrue(rs is StructureDefinition);
+
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Money");
+            Assert.IsNotNull(summary);
+            var dt = summary.LoadResource();
+            Assert.IsNotNull(dt);
+            Assert.IsTrue(dt is StructureDefinition);
+
+            // Try to find a core extension
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/valueset-history");
+            Assert.IsNotNull(summary);
+            var ext = summary.LoadResource();
+            Assert.IsNotNull(ext);
+            Assert.IsTrue(ext is StructureDefinition);
+
+            // Try to find an additional US profile (they are distributed with the spec for now)
+            summary = summaries.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/cqif-questionnaire");
+            Assert.IsNotNull(summary);
+            var us = summary.LoadResource();
+            Assert.IsNotNull(us);
+            Assert.IsTrue(us is StructureDefinition);
+        }
+
+        [TestMethod]
+        public void ListSummaries()
+        {
+            var source = new DirectorySource(Path.Combine(DirectorySource.SpecificationDirectory, "TestData", "snapshot-test"),
+                new DirectorySourceSettings { IncludeSubDirectories = true });
+
+            var sd = source.ListSummaries(ResourceType.StructureDefinition); Assert.IsTrue(sd.Any());
+            var sm = source.ListSummaries(ResourceType.StructureMap); Assert.IsTrue(sd.Any());
+            var de = source.ListSummaries(ResourceType.DataElement); Assert.IsFalse(de.Any());
+            var cf = source.ListSummaries(ResourceType.CapabilityStatement); Assert.IsTrue(cf.Any());
+            var md = source.ListSummaries(ResourceType.MessageDefinition); Assert.IsFalse(md.Any());
+            var od = source.ListSummaries(ResourceType.OperationDefinition); Assert.IsTrue(od.Any());
+            var sp = source.ListSummaries(ResourceType.SearchParameter); Assert.IsFalse(sp.Any());
+            var cd = source.ListSummaries(ResourceType.CompartmentDefinition); Assert.IsFalse(md.Any());
+            var ig = source.ListSummaries(ResourceType.ImplementationGuide); Assert.IsFalse(ig.Any());
+
+            var cs = source.ListSummaries(ResourceType.CodeSystem); Assert.IsFalse(cs.Any());
+            var vs = source.ListSummaries(ResourceType.ValueSet); Assert.IsTrue(vs.Any());
+            var cm = source.ListSummaries(ResourceType.ConceptMap); Assert.IsFalse(cm.Any());
+            var ep = source.ListSummaries(ResourceType.ExpansionProfile); Assert.IsFalse(ep.Any());
+            var ns = source.ListSummaries(ResourceType.NamingSystem); Assert.IsFalse(ns.Any());
+
+            var all = source.ListSummaries();
+
+            Assert.AreEqual(sd.Count() + sm.Count() + de.Count() + cf.Count() + md.Count() + od.Count() +
+                        sp.Count() + cd.Count() + ig.Count() + cs.Count() + vs.Count() + cm.Count() +
+                        ep.Count() + ns.Count(), all.Count());
+        }
+
+        [TestMethod]
+        public async Tasks.Task TestThreadSafety()
+        {
+            // Verify thread safety by resolving same uri simultaneously from different threads
+            // DirectorySource should synchronize access and only call prepare once.
+
+            const int threadCount = 25;
+            const string uri = @"http://example.org/fhir/StructureDefinition/human-group";
+
+            var source = new DirectorySource(Path.Combine(DirectorySource.SpecificationDirectory, "TestData", "snapshot-test"),
+                new DirectorySourceSettings { IncludeSubDirectories = true });
+
+            var tasks = new Tasks.Task[threadCount];
+            var results = new(Resource resource, ArtifactSummary summary, int threadId, TimeSpan start, TimeSpan stop)[threadCount];
+
+            var sw = new Stopwatch();
+            sw.Start();
+            for (int i = 0; i < threadCount; i++)
+            {
+                var idx = i;
+                tasks[i] = Tasks.Task.Run(
+                    () =>
+                    {
+#if DOTNETFW
+                        var threadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+#else
+                        const int threadId = 0;
+#endif
+                        var start = sw.Elapsed;
+                        var resource = source.ResolveByCanonicalUri(uri);
+                        var summary = source.ListSummaries().ResolveByUri(uri);
+                        var stop = sw.Elapsed;
+                        results[idx] = (resource, summary, threadId, start, stop);
+                    }
+                );
+            }
+
+            await Tasks.Task.WhenAll(tasks);
+            sw.Stop();
+
+            var first = results[0];
+            for (int i = 0; i < threadCount; i++)
+            {
+                var result = results[i];
+                var duration = result.stop.Subtract(result.start);
+                Debug.WriteLine($"{i:0#} Thread: {result.threadId:00#} | Start: {result.start.TotalMilliseconds:0000.00} | Stop: {result.stop.TotalMilliseconds:0000.00} | Duration: {duration.TotalMilliseconds:0000.00}");
+                Assert.IsNotNull(result.resource);
+                Assert.IsNotNull(result.summary);
+                // Verify that all threads return the same summary instances
+                Assert.AreSame(first.summary, result.summary);
+            }
+        }
+
+    }
+}

--- a/src/Hl7.Fhir.Specification.Tests/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/TimingSource.cs
@@ -25,8 +25,6 @@ namespace Hl7.Fhir.Specification.Tests
 
             public TimingSource(IConformanceSource source) { _source = source; }
 
-            public ReadOnlyCollection<ArtifactSummary> ListSummaries() => throw new NotImplementedException();
-
             public IEnumerable<ConceptMap> FindConceptMaps(string sourceUri = null, string targetUri = null)
                 => measureDuration(() => _source.FindConceptMaps(sourceUri, targetUri));
 

--- a/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/IConformanceSource.cs
@@ -9,17 +9,12 @@
 using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Specification.Source.Summary;
-using System.Collections.ObjectModel;
 
 namespace Hl7.Fhir.Specification.Source
 {
     /// <summary>Interface for browsing and resolving FHIR conformance resources.</summary>
     public interface IConformanceSource : IResourceResolver
     {
-        /// <summary>Returns a list of summary information for all the FHIR artifacts provided by the source.</summary>
-        ReadOnlyCollection<ArtifactSummary> ListSummaries();
-
         // [WMR 20171204] We could convert the following members to extension methods (ConformanceSourceExtensions)
         // Breaking change, but decreases interface implementer burden
 
@@ -50,18 +45,6 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uniqueId">The unique id of a <see cref="NamingSystem"/> resource.</param>
         /// <returns>A <see cref="NamingSystem"/> resource, or <c>null</c>.</returns>
         NamingSystem FindNamingSystem(string uniqueId);
-    }
-
-    /// <summary>Extension methods for the <see cref="IConformanceSource"/> interface.</summary>
-    public static class ConformanceSourceExtensions
-    {
-        /// <summary>Returns a list of <see cref="ArtifactSummary"/> instances with error information.</summary>
-        /// <returns>A <see cref="List{T}"/> of <see cref="ArtifactSummary"/> instances.</returns>
-        public static IEnumerable<ArtifactSummary> Errors(this IConformanceSource source) => source.ListSummaries().Errors();
-
-        /// <summary>Returns a list of <see cref="ArtifactSummary"/> instances for resources of the specified <see cref="ResourceType"/>.</summary>
-        /// <returns>A <see cref="List{T}"/> of <see cref="ArtifactSummary"/> instances.</returns>
-        public static IEnumerable<ArtifactSummary> Summaries(this IConformanceSource source, ResourceType resourceType) => source.ListSummaries().OfResourceType(resourceType);
     }
 
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/ISummarySource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ISummarySource.cs
@@ -1,0 +1,34 @@
+﻿/* 
+ * Copyright (c) 2018, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/ewoutkramer/fhir-net-api/blob/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source.Summary;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Hl7.Fhir.Specification.Source
+{
+    /// <summary>Interface for browsing and resolving FHIR conformance resources with summary information.</summary>
+    public interface ISummarySource : IConformanceSource
+    {
+        // <summary>Returns a list of summary information for all the FHIR artifacts provided by the source.</summary>
+        ReadOnlyCollection<ArtifactSummary> ListSummaries();
+    }
+
+    /// <summary>Extension methods for the <see cref="ISummarySource"/> interface.</summary>
+    public static class SummarySourceExtensions
+    {
+        /// <summary>Returns a list of <see cref="ArtifactSummary"/> instances with error information.</summary>
+        /// <returns>A <see cref="List{T}"/> of <see cref="ArtifactSummary"/> instances.</returns>
+        public static IEnumerable<ArtifactSummary> ListSummaryErrors(this ISummarySource source) => source.ListSummaries().Errors();
+
+        /// <summary>Returns a list of <see cref="ArtifactSummary"/> instances for resources of the specified <see cref="ResourceType"/>.</summary>
+        /// <returns>A <see cref="List{T}"/> of <see cref="ArtifactSummary"/> instances.</returns>
+        public static IEnumerable<ArtifactSummary> ListSummaries(this ISummarySource source, ResourceType resourceType) => source.ListSummaries().OfResourceType(resourceType);
+    }
+}

--- a/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Specification.Source
 {
     /// <summary>Reads FHIR artifacts (Profiles, ValueSets, ...) from a ZIP archive. Thread-safe.</summary>
     [DebuggerDisplay(@"\{{DebuggerDisplay,nq}}")]
-    public class ZipSource : IConformanceSource, IArtifactSource
+    public class ZipSource : ISummarySource, IConformanceSource, IArtifactSource
     {
         public const string SpecificationZipFileName = "specification.zip";
 
@@ -129,9 +129,6 @@ namespace Hl7.Fhir.Specification.Source
 
         #region IConformanceSource
 
-        /// <summary>Returns a list of summary information for all the FHIR artifacts in the ZIP archive.</summary>
-        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
-
         /// <summary>List all resource uris, optionally filtered by type.</summary>
         /// <param name="filter">A <see cref="ResourceType"/> enum value.</param>
         /// <returns>A <see cref="IEnumerable{T}"/> sequence of uri strings.</returns>
@@ -161,6 +158,13 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uniqueId">The unique id of a <see cref="NamingSystem"/> resource.</param>
         /// <returns>A <see cref="NamingSystem"/> resource, or <c>null</c>.</returns>
         public NamingSystem FindNamingSystem(string uniqueId) => FileSource.FindNamingSystem(uniqueId);
+
+        #endregion
+
+        #region ISummarySource
+
+        /// <summary>Returns a list of summary information for all the FHIR artifacts in the ZIP archive.</summary>
+        public ReadOnlyCollection<ArtifactSummary> ListSummaries() => FileSource.ListSummaries();
 
         #endregion
 


### PR DESCRIPTION
* #543 Remove ListSummaries() from IConformanceSource
previous build introduced new method IConformanceSource.ListSummaries(), however this breaks binary compatibility => move this method to a separate new interface ISummarySource.

* #545 Support XML/JSON serialization to in-memory DOM
Implement public methods to serialize to Xml/Json document
(FhirXmlSerializer, FhirJsonSerializer)