### PR TITLE
fix: remove trailing slash in case of Transaction

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Tests.Rest
         //public static Uri testEndpoint = new Uri("https://localhost:44346/fhir");
         //public static Uri testEndpoint = new Uri("http://localhost:1396/fhir");
         public static Uri testEndpoint = new Uri("http://test.fhir.org/r3");
-        //public static Uri testEndpoint = new Uri("http://vonk.furore.com");
+        //public static Uri testEndpoint = new Uri("http://vonk.fire.ly");
         //public static Uri testEndpoint = new Uri("https://api.fhir.me");
         //public static Uri testEndpoint = new Uri("http://fhirtest.uhn.ca/baseDstu3");
         //public static Uri testEndpoint = new Uri("http://localhost:49911/fhir");

--- a/src/Hl7.Fhir.Core.Tests/Rest/TransactionBuilderTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/TransactionBuilderTests.cs
@@ -161,5 +161,22 @@ namespace Hl7.Fhir.Test
 
             Assert.AreEqual("W/\"314\"", b.Entry[0].Request.IfMatch);
         }
+
+        /// <summary>
+        /// Unit test to prove issue 536: 
+        /// https://github.com/ewoutkramer/fhir-net-api/issues/536
+        /// </summary>
+        [TestMethod]
+        public void TestTransactionWithForwardSlash()
+        {
+            var tx2 = new TransactionBuilder("http://myserver.org/fhir/");
+            var bundle = tx2.Get("@Patient/1").ToBundle();
+
+            var tx = new TransactionBuilder("http://myserver.org/fhir/")
+                .Transaction(bundle);
+
+            var b = tx.ToBundle();
+            Assert.IsFalse(b.Entry[0].Request.Url.EndsWith(@"/"), "Url cannot end with forward slash");
+        }
     }
 }

--- a/src/Hl7.Fhir.Core/Rest/TransactionBuilder.cs
+++ b/src/Hl7.Fhir.Core/Rest/TransactionBuilder.cs
@@ -354,7 +354,10 @@ namespace Hl7.Fhir.Rest
         {
             var entry = newEntry(Bundle.HTTPVerb.POST, InteractionType.Transaction);
             entry.Resource = transaction;
-            addEntry(entry, newRestUrl());
+            var url = _baseUrl;
+            if (url.EndsWith("/"))  // in case of a transaction the url cannot end with a forward slash. Remove it here.
+                url = url.TrimEnd('/');
+            addEntry(entry, new RestUrl(url));
 
             return this;
         }


### PR DESCRIPTION
This fix is part of issue #536 