### PR TITLE
Remove Escaped characters from POST body on search

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/EntryToHttpExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/EntryToHttpExtensions.cs
@@ -133,9 +133,9 @@ namespace Hl7.Fhir.Rest
                 foreach(Parameters.ParameterComponent parameter in ((Parameters)data).Parameter)
                 {
                     if (!string.IsNullOrEmpty(bodyParameters)) bodyParameters += "&";
-                    bodyParameters += $"{parameter.Name}={parameter.Value}";
+                    bodyParameters += $"{Uri.EscapeDataString(parameter.Name)}={Uri.EscapeDataString(parameter.Value.ToString())}";
                 }
-                body = Encoding.UTF8.GetBytes(Uri.EscapeDataString(bodyParameters));
+                body = Encoding.UTF8.GetBytes(bodyParameters);
                 request.ContentType = "application/x-www-form-urlencoded";
             }
             else


### PR DESCRIPTION
In regards to #213, #479 and #530 which was recently released. The current implementation encodes and escapes the body on the request. This is not an apparent HTTP standard and breaks the x-www-form-urlencoded processing on FHIR servers I have tested with several servers from the sample list, as well as local test servers.

I first noticed this when connecting to several test servers after converting our usages from GET to POST and having wildly different results.

This is a replacement Pull Request for #587

Squashed commit of the following:

commit 0e127ee67c2f5e86628d86a7ccb4185153a83d7d
Author: Ryan Kelley <ryan.kelley@royaljay.net>
Date:   Wed May 2 15:53:22 2018 -0600

    Fixing tests

commit 2ace43ac7403db2515a6448f87bfa0eda33ac1e2
Author: Ryan Kelley <ryan.kelley@royaljay.net>
Date:   Tue May 1 13:50:39 2018 -0600

    Add encoding to property names on form post

commit 4b88a38c64ac97739165b0e9b6e5fdca068f8c1c
Author: Ryan Kelley <ryan.kelley@royaljay.net>
Date:   Mon Apr 23 16:11:10 2018 -0600

    Updated to escape the values, but not the entire body

commit a59a2cfd64ba1972820e9a8caf11d70aa56fff30
Author: Ryan Kelley <ryan.kelley@royaljay.net>
Date:   Mon Apr 23 15:19:47 2018 -0600

    Remove escaped characters from POST body on search re: #479