### PR TITLE
rewrite: used Lazy<> to avoid the cost of building setter/getter DSTU2

### DIFF
--- a/src/Hl7.Fhir.Core/Introspection/PropertyInfoExtensions.cs
+++ b/src/Hl7.Fhir.Core/Introspection/PropertyInfoExtensions.cs
@@ -1,13 +1,15 @@
-﻿#if USE_CODE_GEN
-
+﻿
 /*
  * This code is based on the article by Mariano Omar Rodiguez found here: 
  * http://weblogs.asp.net/marianor/archive/2009/04/10/using-expression-trees-to-get-property-getter-and-setters.aspx
  */
 
 using System;
-using System.Linq.Expressions;
 using System.Reflection;
+
+#if USE_CODE_GEN
+using System.Linq.Expressions;
+#endif
 
 namespace Hl7.Fhir.Introspection
 {
@@ -18,15 +20,24 @@ namespace Hl7.Fhir.Introspection
             if (typeof(T) != propertyInfo.DeclaringType)
                 throw new ArgumentException("Generic param T must agree with the declaring type of the property.", nameof(propertyInfo));
 
+#if USE_CODE_GEN
             return (Func<T, object>)buildGetter(propertyInfo, typeof(T));
+#else
+            return instance => propertyInfo.GetValue(instance, null);
+#endif
         }
 
 
         public static Func<object, object> GetValueGetter(this PropertyInfo propertyInfo)
         {
+#if USE_CODE_GEN
             return (Func<object, object>)buildGetter(propertyInfo, typeof(object));
+#else
+            return instance => propertyInfo.GetValue(instance, null);
+#endif
         }
 
+#if USE_CODE_GEN
         private static Delegate buildGetter(PropertyInfo propertyInfo, Type instanceType)
         {
             var instance = Expression.Parameter(instanceType, "i");    // get(instanceType i) =>
@@ -40,15 +51,21 @@ namespace Hl7.Fhir.Introspection
 
             return Expression.Lambda(convertOut, instance).Compile();
         }
+#endif
 
         public static Action<T, object> GetValueSetter<T>(this PropertyInfo propertyInfo)
         {
             if (typeof(T) != propertyInfo.DeclaringType)
                 throw new ArgumentException("Generic param T must agree with the declaring type of the property.", nameof(propertyInfo));
-
+#if USE_CODE_GEN
             return (Action<T, object>)buildSetter(propertyInfo, typeof(T));
+#else
+            return (instance, value) => propertyInfo.SetValue(instance, value, null);
+#endif
+
         }
 
+#if USE_CODE_GEN
         private static Delegate buildSetter(this PropertyInfo propertyInfo, Type instanceType)
         {
             var instance = Expression.Parameter(instanceType, "i");    // set(object i, object a) =>
@@ -65,12 +82,15 @@ namespace Hl7.Fhir.Introspection
 
             return Expression.Lambda(setterCall, instance, argument).Compile();
         }
+#endif
 
         public static Action<object, object> GetValueSetter(this PropertyInfo propertyInfo)
         {
+#if USE_CODE_GEN
             return (Action<object, object>)buildSetter(propertyInfo, typeof(object));
+#else
+            return (instance, value) => propertyInfo.SetValue(instance, value, null);
+#endif
         }
     }
 }
-
-#endif

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -723,7 +723,7 @@ namespace Hl7.Fhir.Specification.Tests
             elements.InsertRange(idx, inserts);
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         // [Ignore]
         public void GeneratePatientWithExtensionsSnapshot()
         {
@@ -2394,7 +2394,7 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandResources(coreTypeUrls.ToArray());
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void TestExpandAllCoreResources()
         {
             // Generate snapshots for all core resources, in the original order as they are defined
@@ -3177,7 +3177,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestObservationProfileWithExtensions() => testObservationProfileWithExtensions(false);
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void TestObservationProfileWithExtensions_ExpandAll() => testObservationProfileWithExtensions(true);
 
         void testObservationProfileWithExtensions(bool expandAll)

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Specification.Tests
     [TestClass]
     public class ArtifactSourceTests
     {
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void ZipCacherShouldCache()
         {
             var cacheKey = Guid.NewGuid().ToString();
@@ -182,7 +182,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("invalid.xml", Path.GetFileName(error.Origin));
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void FileSourceSkipsExecutables()
         {
             var fa = new DirectorySource(_testPath);
@@ -223,7 +223,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void TestZipSourceMask()
         {
             var zipFile = Path.Combine(Directory.GetCurrentDirectory(), "specification.zip");

--- a/src/Hl7.Fhir.Specification.Tests/Source/SummarySourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/SummarySourceTests.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Specification.Tests
         static ISummarySource source = null;
 
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void GetSomeArtifactsBySummary()
         {
             var fa = source;

--- a/src/Hl7.FhirPath.Tests/PocoTests/FhirPathParallelTest.cs
+++ b/src/Hl7.FhirPath.Tests/PocoTests/FhirPathParallelTest.cs
@@ -60,7 +60,6 @@ namespace Vonk.Core.Tests.Support
         /// <returns></returns>
         [Theory]
         [MemberData(nameof(GetSelectMethods))]
-        [Trait("TestCategory", "LongRunner")]
         public async T.Task MassiveParallelSelectsShouldBeCorrect(string testDescriptor, Func<IElementNavigator, string, EvaluationContext, IEnumerable<IElementNavigator>> selector)
         {
             var actual = new ConcurrentBag<(string canonical, DataElement resource)>();

--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathTest.cs
@@ -96,7 +96,7 @@ namespace Hl7.FhirPath.Tests
             Assert.IsTrue(TypeInfo.ByName("something") != TypeInfo.ByName("somethingElse"));
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("LongRunner")]
         public void TestFhirPathPolymporphism()
         {
             var patient = new Hl7.Fhir.Model.Patient() { Active = false };


### PR DESCRIPTION
used Lazy<> to avoid the cost of building setter/getter expressions when not using poco's