### PR TITLE
Faster generation of property getters and setters with reflection emit

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -40,6 +40,8 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />

--- a/src/Hl7.Fhir.Core/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Core/Introspection/PropertyMapping.cs
@@ -90,9 +90,6 @@ namespace Hl7.Fhir.Introspection
 
             referredTypes = foundTypes;
 
-            // May need to generate getters/setters using pre-compiled expression trees for performance.
-            // See http://weblogs.asp.net/marianor/archive/2009/04/10/using-expression-trees-to-get-property-getter-and-setters.aspx
-
 #if USE_CODE_GEN
             result._getter = prop.GetValueGetter();
             result._setter = prop.GetValueSetter();


### PR DESCRIPTION
Hi @ewoutkramer, great optimization, we can also avoid the penalty of `Lambda.Compile()` by using a little bit of lightweight codegen. Given there is a known context around the models it seems relatively straight forward to do.

By calling Compile vs ILGen I was getting this type of perf to generate 100,000 getters:
```
00:00:00.8095830 (Generated using ILGen)
00:00:19.8382566 (Generated using Expression.compile)
```