### PR TITLE
Feature/r4 validation fixes

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -66,7 +66,7 @@ namespace Hl7.Fhir.FhirPath
         {
             t.Add("hasValue", (ElementModel.IElementNavigator f) => f.HasValue(), doNullProp: false);
             t.Add("resolve", (ElementModel.IElementNavigator f, EvaluationContext ctx) => resolver(f,ctx), doNullProp: false);
-            t.Add("htmlchecks", (ElementModel.IElementNavigator f) => f.HtmlChecks(), doNullProp: false);
+            t.Add("htmlChecks", (ElementModel.IElementNavigator f) => f.HtmlChecks(), doNullProp: false);
 
             return t;
 

--- a/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
@@ -23,6 +23,12 @@ namespace Hl7.Fhir.Validation
         public ITerminologyService TerminologyService { get; set; }
 
         /// <summary>
+        /// An instance of the FhirPath compiler to use when evaluating constraints
+        /// (provide this if you have custom functions included in the symbol table)
+        /// </summary>
+        public Hl7.FhirPath.FhirPathCompiler FhirPathCompiler { get; set; }
+
+        /// <summary>
         /// The validator needs StructureDefinitions to have a snapshot form to function. If a StructureDefinition
         /// without a snapshot is encountered, should the validator generate the snapshot from the differential
         /// present in the StructureDefinition? Default is 'false'.

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -282,6 +282,9 @@ namespace Hl7.Fhir.Validation
         {
             get
             {
+                // Use a provided compiler
+                if (Settings?.FhirPathCompiler != null)
+                    return Settings.FhirPathCompiler;
 
                 if (_fpCompiler == null)
                 {
@@ -290,6 +293,9 @@ namespace Hl7.Fhir.Validation
                     symbolTable.AddFhirExtensions();
 
                     _fpCompiler = new FhirPathCompiler(symbolTable);
+
+                    // Should this be exposed?
+                    Settings.FhirPathCompiler = _fpCompiler;
                 }
 
                 return _fpCompiler;


### PR DESCRIPTION
The case sensitivity of the htmlChecks is incorrect.
Also include an opportunity to pass the fhirpath compiler to the validator (otherwise custom function tables will not be used)