### PR TITLE
Bugfix/remove warnings stu3

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/FhirEvaluationContext.cs
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.FhirPath
         [Obsolete("Please use CreateDefault() instead of this member, which may cause raise conditions.")]
         new public static readonly FhirEvaluationContext Default = new FhirEvaluationContext();
 
-        public static FhirEvaluationContext CreateDefault() => new FhirEvaluationContext();
+        public new static FhirEvaluationContext CreateDefault() => new FhirEvaluationContext();
 
         public FhirEvaluationContext() : base()
         {

--- a/src/Hl7.Fhir.Core/Support/CanonicalUrlConflictException.cs
+++ b/src/Hl7.Fhir.Core/Support/CanonicalUrlConflictException.cs
@@ -10,10 +10,10 @@ namespace Hl7.Fhir.Support
     /// The exception that is throw when the artifact resolver encounters conflicting conformance resources with identical canonical urls.
     /// <para>
     /// Obsolete. The FHIR API no longer throws this exception.
-    /// Clients should catch the new <see cref="ResolvingConflictException"/> instead.
+    /// Clients should catch the new <see cref="T:Hl7.Fhir.Support.ResolvingConflictException"/> instead.
     /// </para>
     /// </summary>
-    /// <seealso cref="ResolvingConflictException"/>
+    /// <seealso cref="T:Hl7.Fhir.Support.ResolvingConflictException"/>
     [Obsolete("This exception is obsolete and has been replaced by the more generic UrlConflictException. The FHIR API longer throws this exception. New clients should catch the UrlConflictException instead.")]
     public class CanonicalUrlConflictException : Exception
     {


### PR DESCRIPTION
Cleaning up the compiler warnings. The obsolete warnings (CS0618) still exists and will be removed in future release