### PR TITLE
Add type-less overload for Parse method #726

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -53,6 +53,20 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.AreEqual(metaXml, xml);
         }
 
+        [TestMethod]
+        public void ParsePatientXmlNullType()
+        {
+            string xmlPacientTest = TestDataHelper.ReadTestData("TestPatient.xml");
+            
+            var poco = new FhirXmlParser().Parse(xmlPacientTest);
+            var xml = new FhirXmlSerializer().SerializeToString(poco);
+            
+            Assert.AreEqual(((Patient)poco).Id, "pat1");
+            Assert.AreEqual(((Patient)poco).Contained.First().Id, "1");
+            Assert.AreEqual(((Patient)poco).Name.First().Family.First(), "Donald");
+            Assert.AreEqual(((Patient)poco).ManagingOrganization.Reference, "Organization/1");
+        }
+
         internal FhirXmlSerializer FhirXmlSerializer = new FhirXmlSerializer();
         internal FhirJsonSerializer FhirJsonSerializer = new FhirJsonSerializer();
 
@@ -631,10 +645,10 @@ namespace Hl7.Fhir.Tests.Serialization
         public void DateTimeOffsetAccuracyTest()
         {
             var patient = new Patient { Meta = new Meta { LastUpdated = DateTimeOffset.UtcNow } };
-            var json = new FhirJsonSerializer().SerializeToString(patient); 
+            var json = new FhirJsonSerializer().SerializeToString(patient);
             var res = new FhirJsonParser().Parse<Patient>(json);
             Assert.IsTrue(patient.IsExactly(res), "1");
-           
+
             // Is the parsing still correct without milliseconds?
             patient = new Patient { Meta = new Meta { LastUpdated = new DateTimeOffset(2018, 8, 13, 13, 41, 56, TimeSpan.Zero)} };
             json = "{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2018-08-13T13:41:56+00:00\"}}";
@@ -642,7 +656,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(patient.IsExactly(res), "2");
 
             // Is the serialization still correct without milliseconds?
-            var json2 = new FhirJsonSerializer().SerializeToString(patient); 
+            var json2 = new FhirJsonSerializer().SerializeToString(patient);
             Assert.AreEqual(json, json2, "3");
 
             // Is the parsing still correct with a few milliseconds and TimeZone?

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -59,7 +59,6 @@ namespace Hl7.Fhir.Tests.Serialization
             string xmlPacientTest = TestDataHelper.ReadTestData("TestPatient.xml");
             
             var poco = new FhirXmlParser().Parse(xmlPacientTest);
-            var xml = new FhirXmlSerializer().SerializeToString(poco);
             
             Assert.AreEqual(((Patient)poco).Id, "pat1");
             Assert.AreEqual(((Patient)poco).Contained.First().Id, "1");
@@ -80,6 +79,18 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.AreEqual(metaJson, json);
         }
 
+        [TestMethod]
+        public void ParsePatientJsonNullType()
+        {
+            string jsonPatient = TestDataHelper.ReadTestData("TestPatient.json");
+
+            var poco = new FhirJsonParser().Parse(jsonPatient);
+
+            Assert.AreEqual(((Patient)poco).Id, "pat1");
+            Assert.AreEqual(((Patient)poco).Contained.First().Id, "1");
+            Assert.AreEqual(((Patient)poco).Name.First().Family.First(), "Donald");
+            Assert.AreEqual(((Patient)poco).ManagingOrganization.Reference, "Organization/1");
+        }
 
         [TestMethod]
         public void AvoidBOMUse()

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
@@ -27,17 +27,17 @@ namespace Hl7.Fhir.Serialization
         // TODO: True for DSTU2, should be false in STU3
         private readonly FhirJsonParsingSettings jsonNodeSettings = new FhirJsonParsingSettings { AllowJsonComments = true };
 
-        public Base Parse(string json, Type dataType)
+        public Base Parse(string json, Type dataType = null)
         {
             var jsonReader =
-                FhirJsonNode.Parse(json, ModelInfo.GetFhirTypeNameForType(dataType), jsonNodeSettings);
+                FhirJsonNode.Parse(json, dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null, jsonNodeSettings);
             return Parse(jsonReader, dataType);
         }
 
-        public Base Parse(JsonReader reader, Type dataType)
+        public Base Parse(JsonReader reader, Type dataType = null)
         {
             var jsonReader =
-                FhirJsonNode.Read(reader, ModelInfo.GetFhirTypeNameForType(dataType), jsonNodeSettings);
+                FhirJsonNode.Read(reader, dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null, jsonNodeSettings);
             return Parse(jsonReader, dataType);
         }
     }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
@@ -36,7 +36,7 @@ namespace Hl7.Fhir.Serialization
             return Parse(xmlReader, dataType);
         }
 
-        public Base Parse(XmlReader reader, Type dataType)
+        public Base Parse(XmlReader reader, Type dataType = null)
         {
             var xmlReader = FhirXmlNode.Read(reader, buildNodeSettings(Settings));
             return Parse(xmlReader, dataType);

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Serialization
                     DisallowSchemaLocation = Settings.DisallowXsiAttributesOnRoot,
                 };
 
-        public Base Parse(string xml, Type dataType)
+        public Base Parse(string xml, Type dataType = null)
         {
             var xmlReader = FhirXmlNode.Parse(xml, buildNodeSettings(Settings));
             return Parse(xmlReader, dataType);


### PR DESCRIPTION
Made dataType parameter optional in FhirXmlParser. Added Unit test for this change.