### PR TITLE
fix: xml.xsd/fhir-xhtml.xsd accidentally got included in the NuGet

### DIFF
--- a/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
+++ b/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
@@ -16,22 +16,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="xhtml\fhir-xhtml.xsd" />
-    <EmbeddedResource Include="xhtml\xml.xsd" />
+    <EmbeddedResource Include="xhtml\fhir-xhtml.xsd">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="xhtml\xml.xsd">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="xhtml\fhir-xhtml.xsd" />
     <None Remove="xhtml\xml.xsd" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="xhtml\fhir-xhtml.xsd">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="xhtml\xml.xsd">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The embedded resources (xsd files needed for xhtml validation) were also included as Content items, so they appeared in the NuGet. I have removed them from the output now.