### PR TITLE
feature: turn incorrect displays for codes into warnings

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -101,9 +101,10 @@ namespace Hl7.Fhir.Specification.Tests
                 display: "Not a Number");
             Assert.True(result.Success);
 
-            result = svc.ValidateCode(vsUrl, code: "NaN", system: "http://hl7.org/fhir/data-absent-reason",
-                display: "Not any Number");
-            Assert.False(result.Success);
+            // The spec is not clear on the behaviour of incorrect displays - so don't test it here
+            //result = svc.ValidateCode(vsUrl, code: "NaN", system: "http://hl7.org/fhir/data-absent-reason",
+            //    display: "Not any Number");
+            //Assert.True(result.Success);
 
             result = svc.ValidateCode("http://hl7.org/fhir/ValueSet/v3-AcknowledgementDetailCode", code: "_AcknowledgementDetailNotSupportedCode",
                 system: "http://hl7.org/fhir/v3/AcknowledgementDetailCode");

--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -146,6 +146,23 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Fact]
+        public void LocalTSDisplayIncorrectAsWarning()
+        {
+            var svc = new LocalTerminologyService(_resolver);
+
+            var vsUrl = "http://hl7.org/fhir/ValueSet/data-absent-reason";
+            var result = svc.ValidateCode(vsUrl, code: "NaN", system: "http://hl7.org/fhir/data-absent-reason",
+                display: "Not a Number");
+            Assert.True(result.Success);
+            Assert.Equal(0, result.Warnings);
+
+            result = svc.ValidateCode(vsUrl, code: "NaN", system: "http://hl7.org/fhir/data-absent-reason",
+                        display: "Certainly Not a Number");
+            Assert.True(result.Success);
+            Assert.Equal(1, result.Warnings);
+        }
+
+        [Fact]
         public void LocalTermServiceValidateCodeTest()
         {
             var svc = new LocalTerminologyService(_resolver);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BindingValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BindingValidationTests.cs
@@ -104,7 +104,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             c.Display = "Not a NumberX";
             result = val.ValidateBinding(c, binding);
-            Assert.False(result.Success);
+            Assert.True(result.Success);        // local terminology service treats incorrect displays as warnings (GH#624)
 
             // But this won't, it's also a composition, but without expansion - the local term server won't help you here
             var binding2 = new ElementDefinition.BindingComponent

--- a/src/Hl7.Fhir.Specification/Support/Issue.cs
+++ b/src/Hl7.Fhir.Specification/Support/Issue.cs
@@ -137,7 +137,7 @@ namespace Hl7.Fhir.Support
         // Terminology specific errors
         public static readonly Issue TERMINOLOGY_CODE_NOT_IN_VALUESET = Create(6001, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
         public static readonly Issue TERMINOLOGY_ABSTRACT_CODE_NOT_ALLOWED = Create(6002, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
-        public static readonly Issue TERMINOLOGY_INCORRECT_DISPLAY = Create(6003, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);     
+        public static readonly Issue TERMINOLOGY_INCORRECT_DISPLAY = Create(6003, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.CodeInvalid);     
         public static readonly Issue TERMINOLOGY_SERVICE_FAILED = Create(6004, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.NotSupported);
         public static readonly Issue TERMINOLOGY_NO_CODE_IN_INSTANCE = Create(6005, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
     }


### PR DESCRIPTION
Incorrect displays for codes resulted in an Error outcome in the local terminology service. This will now raise just a warning.

Fixes #624