### PR TITLE
fix: Added [FhirType] to BackboneElement to make sure it gets mapped. 

### DIFF
--- a/src/Hl7.Fhir.Core/Model/BackboneElement.cs
+++ b/src/Hl7.Fhir.Core/Model/BackboneElement.cs
@@ -37,6 +37,7 @@ using System.Runtime.Serialization;
 
 namespace Hl7.Fhir.Model
 {
+    [FhirType("BackboneElement", IsResource = false)]
     public abstract partial class BackboneElement : IModifierExtendable, IBackboneElement
     {
     }


### PR DESCRIPTION
BackboneElement wasn't marked with [FhirType], so the ClassMapper wouldn't map it, therefore the PocoSDProvider wasn't able to retrieve type information for BackboneElement.

Fixes 793