### PR TITLE
feature: new and faster cache for compiled FhirPaths

### DIFF
--- a/src/Hl7.Fhir.Support.Tests/CacheTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/CacheTests.cs
@@ -1,0 +1,69 @@
+﻿using Hl7.Fhir.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.Threading.Tasks.Dataflow;
+
+namespace Hl7.Fhir.Support.Tests
+{
+    [TestClass]
+    public class CacheTests
+    {
+        /// <summary>
+        ///  Gets or sets the test context which provides
+        ///  information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext { get; set; }
+
+        private readonly Cache<string, string> _cache;
+
+        public CacheTests()
+        {
+            _cache = new Cache<string, string>(expr => expr.ToUpper(), new CacheSettings() { MaxCacheSize = 500 });
+        }
+
+        [TestMethod]
+        public void AddingItems()
+        {
+            Cache<string, string> _cache = new Cache<string, string>(expr => expr.ToUpper(), new CacheSettings() { MaxCacheSize = 10 });
+
+            for (int i = 0; i < 20; i++)
+            {
+                var value = _cache.GetValue($"item{i}");
+
+                Assert.AreEqual($"ITEM{i}", value);
+            }
+
+            var result = _cache.GetValue("fhir");
+            Assert.AreEqual("FHIR", result);
+        }
+
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public void AddingItemsParallel()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var actionBlock = new ActionBlock<string>(
+                 input =>
+                 {
+                     _cache.GetValue(input);
+                 }, 
+                 new ExecutionDataflowBlockOptions()
+                 {
+                     MaxDegreeOfParallelism = 20
+                 });
+
+
+            for (int i = 0; i < 20_000; i++)
+            {
+                actionBlock.Post($"item{i}");
+            }
+            actionBlock.Complete();
+            actionBlock.Completion.Wait();
+
+            stopwatch.Stop();
+            TestContext.WriteLine($"Using cache with 20.000 items takes {stopwatch.Elapsed.TotalMilliseconds}ms");
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support/Utility/Cache.cs
+++ b/src/Hl7.Fhir.Support/Utility/Cache.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Utility
+{
+    internal class CacheItem<V> 
+    {
+        public DateTimeOffset LastAccessed { get; private set; } = DateTimeOffset.Now;
+
+        private V  _value;
+        internal V Value
+        {
+            get
+            {
+                LastAccessed = DateTimeOffset.Now;
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                if (value == null)
+                {
+                    throw new ArgumentException($"Do not set the {nameof(Value)} to null.");
+                }
+            }
+        }
+    }
+
+    public class CacheSettings
+    {
+        public int MaxCacheSize { get; set; } = 500;
+        public static CacheSettings CreateDefault() => new CacheSettings();
+
+        public CacheSettings() { }
+
+        public CacheSettings(CacheSettings other)
+        {
+            if (other == null) throw Error.ArgumentNull(nameof(other));
+            other.CopyTo(this);
+        }
+
+        private void CopyTo(CacheSettings other)
+        {
+            if (other == null) throw Error.ArgumentNull(nameof(other));
+            other.MaxCacheSize = MaxCacheSize;
+        }
+
+        public CacheSettings Clone() => new CacheSettings(this);
+    }
+
+    public class Cache<K, V>
+    {
+        private readonly ConcurrentDictionary<K, CacheItem<V>> _cached;
+        private readonly int _minimumCacheSize;
+
+        public CacheSettings Settings { get; private set; }
+
+        public Func<K, V> Retrieve { get; }
+
+        public Cache(Func<K, V> retrieveFunction) : this(retrieveFunction, CacheSettings.CreateDefault())  { }
+
+        public Cache(Func<K, V> retrieveFunction, CacheSettings settings)
+        {
+            _cached = new ConcurrentDictionary<K, CacheItem<V>>();
+            Retrieve = retrieveFunction;
+            Settings = settings.Clone();
+            _minimumCacheSize = (int)Math.Floor(Settings.MaxCacheSize * 0.9);
+        }
+
+        public V GetValue(K key)
+        {
+            if (!_cached.TryGetValue(key, out var result))
+            {
+                result = new CacheItem<V>() { Value = Retrieve(key) };
+                _cached.TryAdd(key, result);
+                EnforceMaxItems();
+            }
+
+            return result.Value;
+        }
+
+        private void EnforceMaxItems()
+        {
+            var currentCount = _cached.Count();
+            if (currentCount > Settings.MaxCacheSize)
+            {
+                // first copy the key value pairs in an array. Otherwise we could have a race condition. See for more information:
+                // https://stackoverflow.com/questions/11692389/getting-argument-exception-in-concurrent-dictionary-when-sorting-and-displaying
+                var copy = _cached.ToArray();
+                var oldestItems = copy.OrderByDescending(entry => entry.Value.LastAccessed).Skip(_minimumCacheSize);
+                foreach (var item in oldestItems)
+                {
+                    _cached.TryRemove(item.Key, out _);
+                }
+            }
+        }
+    }
+}

--- a/src/Hl7.FhirPath/FhirPath/IValueProviderFPExtensions.cs
+++ b/src/Hl7.FhirPath/FhirPath/IValueProviderFPExtensions.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
 using Hl7.FhirPath.Sprache;
 
@@ -17,37 +18,18 @@ namespace Hl7.FhirPath
 {
     public static class IValueProviderFPExtensions
     {
-        private static Dictionary<string, CompiledExpression> _cache = new Dictionary<string, CompiledExpression>();
-        private static List<string> _mruList = new List<string>();      // sigh, no sortedlist in NETSTANDARD 1.0
-        private static readonly Object _cacheLock = new Object();
         public static int MAX_FP_EXPRESSION_CACHE_SIZE = 500;
+        private static readonly Cache<string, CompiledExpression> _cache = new Cache<string, CompiledExpression>(expr => Compile(expr), new CacheSettings() { MaxCacheSize = MAX_FP_EXPRESSION_CACHE_SIZE });
+
+        private static CompiledExpression Compile(string expression)
+        {
+            var compiler = new FhirPathCompiler();
+            return compiler.Compile(expression);
+        }
 
         private static CompiledExpression getCompiledExpression(string expression)
         {
-            lock (_cacheLock)
-            {
-                bool success = _cache.TryGetValue(expression, out CompiledExpression ce);
-
-                if (!success)
-                {
-                    var compiler = new FhirPathCompiler();
-                    ce = compiler.Compile(expression);
-
-                    if (_cache.Count >= MAX_FP_EXPRESSION_CACHE_SIZE)
-                    {
-                        var lruExpression = _mruList.First();
-                        _cache.Remove(lruExpression);
-                        _mruList.Remove(lruExpression);
-                    }
-
-                    _cache.Add(expression, ce);
-                }
-
-                _mruList.Remove(expression);
-                _mruList.Add(expression);
-
-                return ce;
-            }
+            return _cache.GetValue(expression);
         }
 
         public static IEnumerable<ITypedElement> Select(this ITypedElement input, string expression, EvaluationContext ctx = null)
@@ -55,19 +37,19 @@ namespace Hl7.FhirPath
             var evaluator = getCompiledExpression(expression);
             return evaluator(input, ctx ?? EvaluationContext.CreateDefault());
         }
-        
+
         public static object Scalar(this ITypedElement input, string expression, EvaluationContext ctx = null)
         {
             var evaluator = getCompiledExpression(expression);
             return evaluator.Scalar(input, ctx ?? EvaluationContext.CreateDefault());
         }
-        
+
         public static bool Predicate(this ITypedElement input, string expression, EvaluationContext ctx = null)
         {
             var evaluator = getCompiledExpression(expression);
             return evaluator.Predicate(input, ctx ?? EvaluationContext.CreateDefault());
         }
-        
+
         public static bool IsBoolean(this ITypedElement input, string expression, bool value, EvaluationContext ctx = null)
         {
             var evaluator = getCompiledExpression(expression);


### PR DESCRIPTION
Solves issue #561.

Time measurements:

_Before this improvement:_
- hitting the cache 20,000 times in 20 parallel tasks took an average time of 7,850ms (almost 8 sec).

This improvement:
- hitting the cache 20,000 times in 20 parallel tasks took an average time of 5,691ms.
- when we empty the cache by 10% of its size we get even a better performance. Then we have 4,725ms of time. This method is now implemented.
