### PR TITLE
Fix/807 fhir path index of spec change

### DIFF
--- a/src/Hl7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTest.cs
+++ b/src/Hl7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTest.cs
@@ -552,7 +552,7 @@ namespace Hl7.FhirPath.Tests
 
             fixture.IsTrue("Patient.contained.name[0].family.indexOf('ywo') = 4");
             fixture.IsTrue("Patient.contained.name[0].family.indexOf('') = 0");
-            fixture.IsTrue("Patient.contained.name[0].family.indexOf('qq').empty()");
+            fixture.IsTrue("Patient.contained.name[0].family.indexOf('qq') = -1");
 
             fixture.IsTrue("Patient.contained.name[0].family.contains('ywo')");
             fixture.IsTrue("Patient.contained.name[0].family.contains('ywox')=false");

--- a/src/Hl7.FhirPath.Tests/TestData/fhirpath/csharp-tests.xml
+++ b/src/Hl7.FhirPath.Tests/TestData/fhirpath/csharp-tests.xml
@@ -69,7 +69,7 @@
     <output type="boolean">true</output>
   </test>
   <test name="CSharpTest0018" inputfile="fp-test-patient.xml">
-    <expression>Patient.contained.name[0].family.indexOf('qq').empty()</expression>
+    <expression>Patient.contained.name[0].family.indexOf('qq') = -1</expression>
     <output type="boolean">true</output>
   </test>
   <test name="CSharpTest0019" inputfile="fp-test-patient.xml">

--- a/src/Hl7.FhirPath/FhirPath/Functions/StringOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/StringOperators.cs
@@ -32,12 +32,7 @@ namespace Hl7.FhirPath.Functions
 
         public static ITypedElement FpIndexOf(this string me, string fragment)
         {
-            var result = me.IndexOf(fragment);
-
-            if (result == -1)
-                return null;
-            else
-                return new ConstantValue(result);
+            return new ConstantValue(me.IndexOf(fragment));
         }
 
         public static string FpReplace(this string me, string find, string replace)


### PR DESCRIPTION
Fixed Issue 807 by replacing code with standard .net "IndexOf" returned as a "ConstantValue".