### PR TITLE
Fixed IgnoreUnknownElements naming inconsistency.

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
@@ -77,7 +77,7 @@ namespace Hl7.Fhir.Serialization
             {
                 var message = $"Element '{source.Location}' is missing type information.";
 
-                if (_settings.SkipUnknownElements)
+                if (_settings.IgnoreUnknownElements)
                 {
                     ExceptionHandler.NotifyOrThrow(source, ExceptionNotification.Warning(
                         new MissingTypeInformationException(message)));

--- a/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
@@ -16,7 +16,22 @@ namespace Hl7.Fhir.Serialization
         /// <summary>
         /// When encountering a member without type information, just skip it instead of reporting an error.
         /// </summary>
-        public bool SkipUnknownElements;
+        [Obsolete("Use IgnoreUnknownElements instead")]
+        public bool SkipUnknownElements {
+            get
+            {
+                return IgnoreUnknownElements;
+            }
+            set
+            {
+                IgnoreUnknownElements = value;
+            }
+        }
+
+        /// <summary>
+        /// When encountering a member without type information, just skip it instead of reporting an error.
+        /// </summary>
+        public bool IgnoreUnknownElements;
 
         /// <summary>
         /// Format the xml output when converted to a string.
@@ -41,7 +56,7 @@ namespace Hl7.Fhir.Serialization
         {
             if (other == null) throw Error.ArgumentNull(nameof(other));
 
-            other.SkipUnknownElements = SkipUnknownElements;
+            other.IgnoreUnknownElements = IgnoreUnknownElements;
             other.Pretty = Pretty;
         }
 


### PR DESCRIPTION
Made SkipUnknownElements obsolete in the FhirXmlBuilder. SkipUnknownElements now points to IgnoreUnknownElements.
