### PR TITLE
Enable cross-platform development

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/FhirPathExtensionsTest.cs
+++ b/src/Hl7.Fhir.Core.Tests/FhirPathExtensionsTest.cs
@@ -29,7 +29,7 @@ namespace Hl7.Fhir.Tests.Introspection
         public void SetupSource()
         {
             ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
-            var bundleXml = File.ReadAllText("TestData\\bundle-contained-references.xml");
+            var bundleXml = File.ReadAllText(Path.Combine("TestData", "bundle-contained-references.xml"));
 
             _parsed = (new FhirXmlParser()).Parse<Bundle>(bundleXml);
             _bundleElement = new ScopedNode(_parsed.ToTypedElement());

--- a/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
@@ -179,7 +179,7 @@ namespace Hl7.Fhir
         [TestMethod]
         public void IncorrectPathInTwoSuccessiveRepeatingMembers()
         {
-            var xml = File.ReadAllText(@"TestData\issue-444-testdata.xml");
+            var xml = File.ReadAllText(Path.Combine("TestData", "issue-444-testdata.xml"));
             var cs = (new FhirXmlParser()).Parse<Conformance>(xml);
             var nav = cs.ToTypedElement();
 
@@ -194,7 +194,7 @@ namespace Hl7.Fhir
         [TestMethod]
         public void PocoTypedElementPerformance()
         {
-            var xml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var cs = (new FhirXmlParser()).Parse<Patient>(xml);
             var nav = cs.ToTypedElement();
 
@@ -230,7 +230,7 @@ namespace Hl7.Fhir
         [TestMethod]
         public void PocoNavPerformance()
         {
-            var xml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var cs = (new FhirXmlParser()).Parse<Patient>(xml);
 #pragma warning disable CS0618 // Type or member is obsolete
             var nav = cs.ToElementNavigator();

--- a/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
@@ -138,7 +138,7 @@ namespace Hl7.FhirPath.Tests
         [Fact]
         public void ReadsFromNav()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlNode(tpXml).ToSourceNode();
             var nodes = SourceNode.FromNode(nav);
             Assert.True(nav.IsEqualTo(nodes).Success);

--- a/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestInitialize]
         public void SetupSource()
         {
-            var bundleXml = File.ReadAllText("TestData\\bundle-contained-references.xml");
+            var bundleXml = File.ReadAllText(Path.Combine("TestData", "bundle-contained-references.xml"));
 
             var bundle = (new FhirXmlParser()).Parse<Bundle>(bundleXml);
             Assert.IsNotNull(bundle);

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
@@ -106,7 +106,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         public static void RoundtripXml(Func<string, object> navCreator)
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
 
             // will allow whitespace and comments to come through      
             var nav = navCreator(tp);
@@ -139,10 +139,10 @@ namespace Hl7.Fhir.Serialization.Tests
 
         public static void RoundtripJson(Func<string, object> navCreator)
         {
-            //var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            //var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             //compareJson(navCreator, tp);
 
-            var tp = File.ReadAllText(@"TestData\json-edge-cases.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "json-edge-cases.json"));
             compareJson(navCreator, tp);
         }
 

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
@@ -19,7 +19,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanReadThroughTypedNavigator()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNode(tp);
             ParseDemoPatient.CanReadThroughNavigator(nav, typed: true);
         }
@@ -27,7 +27,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ElementNavPerformanceTypedJson()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNode(tp);
             ParseDemoPatient.ElementNavPerformance(nav.ToSourceNode());
         }
@@ -35,7 +35,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ProducesCorrectTypedLocations()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var patient = getJsonNode(tp);
             ParseDemoPatient.ProducedCorrectTypedLocations(patient);
         }
@@ -54,7 +54,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void HasLineNumbersTypedJson()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNode(tp);
             ParseDemoPatient.HasLineNumbers<JsonSerializationDetails>(nav.ToSourceNode());
         }
@@ -62,7 +62,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(@"TestData\BundleWithOneEntry.json");
+            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.json"));
             var nav = getJsonNode(bundle);
             ParseDemoPatient.CheckBundleEntryNavigation(nav);
         }
@@ -77,7 +77,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void PingpongJson()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             // will allow whitespace and comments to come through      
             var navJson = JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
             var xml = navJson.ToXml();

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
@@ -21,7 +21,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanReadThroughUntypedNavigator()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNodeU(tp);
 #pragma warning disable 612, 618
             ParseDemoPatient.CanReadThroughNavigator(nav.ToTypedElement(), typed: false);
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ElementNavPerformanceUntypedJson()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNodeU(tp);
             ParseDemoPatient.ElementNavPerformance(nav);
         }
@@ -39,7 +39,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ProducesCorrectUntypedLocations()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var patient = getJsonNodeU(tp);
 
             ParseDemoPatient.ProducesCorrectUntypedLocations(patient);
@@ -48,7 +48,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void HasLineNumbers()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = getJsonNodeU(tp);
 
             ParseDemoPatient.HasLineNumbers<JsonSerializationDetails>(nav);
@@ -79,7 +79,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(@"TestData\BundleWithOneEntry.json");
+            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.json"));
             var nav = getJsonNodeU(bundle);
 #pragma warning disable 612,618
             ParseDemoPatient.CheckBundleEntryNavigation(nav.ToTypedElement());
@@ -90,7 +90,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanReadEdgeCases()
         {
-            var tpJson = File.ReadAllText(@"TestData\json-edge-cases.json");
+            var tpJson = File.ReadAllText(Path.Combine("TestData", "json-edge-cases.json"));
             var patient = getJsonNodeU(tpJson, new FhirJsonParsingSettings { AllowJsonComments = true });
 
             Assert.AreEqual("Patient", patient.Name);

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -23,7 +23,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanReadThroughTypedNavigator()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlNode(tpXml);
             ParseDemoPatient.CanReadThroughNavigator(nav, typed: true);
         }
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ElementNavPerformanceTypedXml()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlNode(tpXml);
             ParseDemoPatient.ElementNavPerformance(nav.ToSourceNode());
         }
@@ -39,7 +39,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ProducesCorrectTypedLocations()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var patient = getXmlNode(tpXml);
             ParseDemoPatient.ProducedCorrectTypedLocations(patient);
         }
@@ -58,8 +58,11 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CompareXmlJsonParseOutcomes()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
-            var tpJson = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
+            var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            // If on a Unix platform replace \\r\\n in json strings to \\n.
+            if(Environment.NewLine == "\n")
+                tpJson = tpJson.Replace(@"\r\n", @"\n");
             var navXml = getXmlNode(tpXml);
             var navJson = JsonParsingHelpers.ParseToTypedElement(tpJson, new PocoStructureDefinitionSummaryProvider());
 
@@ -76,7 +79,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void HasLineNumbersTypedXml()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlNode(tpXml);
             ParseDemoPatient.HasLineNumbers<XmlSerializationDetails>(nav.ToSourceNode());
         }
@@ -84,7 +87,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(@"TestData\BundleWithOneEntry.xml");
+            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.xml"));
             var node = getXmlNode(bundle);
             ParseDemoPatient.CheckBundleEntryNavigation(node);
         }
@@ -99,7 +102,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void PingpongXml()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             // will allow whitespace and comments to come through      
             var navXml = XmlParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
             var json = navXml.ToJson();
@@ -113,7 +116,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CatchesBasicTypeErrorsWithUnknownRoot()
         {
-            var tpXml = File.ReadAllText(@"TestData\with-errors.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "with-errors.xml"));
             var patient = getXmlNode(tpXml, tnSettings: new TypedElementSettings { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
             var result = patient.VisitAndCatch();
             Assert.AreEqual(11, result.Count);  // 11 syntax errors, unknown root is passed through without errors
@@ -122,7 +125,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CatchesBasicTypeErrors()
         {
-            var tpXml = File.ReadAllText(@"TestData\typeErrors.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "typeErrors.xml"));
             var patient = getXmlNode(tpXml);
             var result = patient.VisitAndCatch();
             Assert.AreEqual(10, result.Count);

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlUntyped.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanReadThroughUntypedNavigator()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlUntyped(tpXml);
 #pragma warning disable 612,618
             ParseDemoPatient.CanReadThroughNavigator(nav.ToTypedElement(), typed: false);
@@ -32,7 +32,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ElementNavPerformanceUntypedXml()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlUntyped(tpXml);
             ParseDemoPatient.ElementNavPerformance(nav);
         }
@@ -40,7 +40,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void ProducesCorrectUntypedLocations()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var patient = getXmlUntyped(tpXml);
 
             ParseDemoPatient.ProducesCorrectUntypedLocations(patient);
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void HasLineNumbers()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlUntyped(tpXml);
 
             ParseDemoPatient.HasLineNumbers<XmlSerializationDetails>(nav);
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void TestPermissiveParsing()
         {
-            var tpXml = File.ReadAllText(@"TestData\all-xml-features.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "all-xml-features.xml"));
 
             // will allow whitespace and comments to come through
             var reader = XmlReader.Create(new StringReader(tpXml));
@@ -211,7 +211,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(@"TestData\BundleWithOneEntry.xml");
+            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.xml"));
             var node = getXmlUntyped(bundle);
 #pragma warning disable 612, 618
             ParseDemoPatient.CheckBundleEntryNavigation(node.ToTypedElement());
@@ -221,7 +221,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CatchesLowLevelErrors()
         {
-            var tpXml = File.ReadAllText(@"TestData\with-errors.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "with-errors.xml"));
             var patient = getXmlUntyped(tpXml);
             var result = patient.VisitAndCatch();
             var originalCount = result.Count;

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanSerializeThroughNavigatorAndCompare()
         {
-            var json = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var json = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
 
             var nav = getJsonElement(json);
             var output = nav.ToJson();
@@ -35,7 +35,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void TestPruneEmptyNodes()
         {
-            var tp = File.ReadAllText(@"TestData\test-empty-nodes.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "test-empty-nodes.json"));
 
             // Make sure permissive parsing is on - otherwise the parser will complain about all those empty nodes
             var nav = getJsonElement(tp, new FhirJsonParsingSettings { PermissiveParsing = true });
@@ -49,7 +49,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanSerializeFromPoco()
         {
-            var tp = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
             var pser = new FhirJsonParser(new ParserSettings { DisallowXsiAttributesOnRoot = false } );
             var pat = pser.Parse<Patient>(tp);
 
@@ -60,7 +60,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void DoesPretty()
         {
-            var json = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var json = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
 
             var nav = getJsonElement(json);
             var output = nav.ToJson();

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanSerializeThroughNavigatorAndCompare()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlElement(tpXml);
             var output = nav.ToXml();
             XmlAssert.AreSame("fp-test-patient.xml", tpXml, output, ignoreSchemaLocation: true);
@@ -37,7 +37,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void TestPruneEmptyNodes()
         {
-            var tpXml = File.ReadAllText(@"TestData\test-empty-nodes.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "test-empty-nodes.xml"));
 
             // Make sure permissive parsing is on - otherwise the parser will complain about all those empty nodes
             var nav = getXmlElement(tpXml, new FhirXmlParsingSettings { PermissiveParsing = true });
@@ -48,7 +48,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void TestElementReordering()
         {
-            var tpXml = File.ReadAllText(@"TestData\patient-out-of-order.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "patient-out-of-order.xml"));
             var nav = getXmlElement(tpXml, new FhirXmlParsingSettings { PermissiveParsing = true });  // since the order is incorrect
             var root = nav.ToXDocument().Root;
 
@@ -63,7 +63,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanSerializeFromPoco()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var pser = new FhirXmlParser(new ParserSettings { DisallowXsiAttributesOnRoot = false });
             var pat = pser.Parse<Patient>(tpXml);
 
@@ -75,8 +75,11 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CompareSubtrees()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
-            var tpJson = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
+            var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            // If on a Unix platform replace \\r\\n in json strings to \\n.
+            if(Environment.NewLine == "\n")
+                tpJson = tpJson.Replace(@"\r\n", @"\n");
             var pat = (new FhirXmlParser()).Parse<Patient>(tpXml);
 
             var navXml = getXmlElement(tpXml);
@@ -101,7 +104,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void DoesPretty()
         {
-            var xml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
 
             var nav = getXmlElement(xml);
             var output = nav.ToXml();

--- a/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -21,8 +22,11 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void CanSerializeSubtree()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
-            var tpJson = File.ReadAllText(@"TestData\fp-test-patient.json");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
+            var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            // If on a Unix platform replace \\r\\n in json strings to \\n.
+            if(Environment.NewLine == "\n")
+                tpJson = tpJson.Replace(@"\r\n", @"\n");
             var pat = (new FhirXmlParser()).Parse<Patient>(tpXml);
 
             // Should work on the parent resource

--- a/src/Hl7.Fhir.Serialization.Tests/StreamJsonResources.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/StreamJsonResources.cs
@@ -13,7 +13,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanThroughBundle()
         {
-            var jsonBundle = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\profiles-types.json");
+            var jsonBundle = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "profiles-types.json"));
             using (var stream = JsonNavigatorStream.FromPath(jsonBundle))
             {
                 Assert.IsTrue(stream.IsBundle);
@@ -54,7 +54,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanThroughSingle()
         {
-            var xmlPatient = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\fp-test-patient.json");
+            var xmlPatient = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "fp-test-patient.json"));
             using (var stream = JsonNavigatorStream.FromPath(xmlPatient))
             {
                 Assert.IsFalse(stream.IsBundle);
@@ -82,7 +82,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         public void ReadCrap()
         {
             // Try a random other xml file
-            var jsonfile = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\source-test\project.assets.json");
+            var jsonfile = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "source-test", "project.assets.json"));
 
             using (var stream = JsonNavigatorStream.FromPath(jsonfile))
             {
@@ -94,7 +94,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanPerformance()
         {
-            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\profiles-types.json");
+            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "profiles-types.json"));
 
             var sw = new Stopwatch();
             sw.Start();

--- a/src/Hl7.Fhir.Serialization.Tests/StreamXmlResources.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/StreamXmlResources.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanThroughBundle()
         {
-            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\profiles-types.xml");
+            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "profiles-types.xml"));
             using (var stream = XmlNavigatorStream.FromPath(xmlBundle))
             {
                 Assert.IsTrue(stream.IsBundle);
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanThroughSingle()
         {
-            var xmlPatient = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\fp-test-patient.xml");
+            var xmlPatient = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "fp-test-patient.xml"));
             using (var stream = XmlNavigatorStream.FromPath(xmlPatient))
             {
                 Assert.IsFalse(stream.IsBundle);
@@ -84,7 +84,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         public void ReadCrap()
         {
             // Try a random other xml file
-            var xmlfile = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\source-test\books.xml");
+            var xmlfile = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "source-test", "books.xml"));
 
             using (var stream = XmlNavigatorStream.FromPath(xmlfile))
             {
@@ -96,7 +96,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         [TestMethod]
         public void ScanPerformance()
         {
-            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), @"TestData\profiles-types.xml");
+            var xmlBundle = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("TestData", "profiles-types.xml"));
 
             var sw = new Stopwatch();
             sw.Start();

--- a/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void Summary()
         {
-            var tpXml = File.ReadAllText(@"TestData\fp-test-patient.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("Patient");
             var inSummary = typeinfo.GetElements().Where(e => e.InSummary).ToList();
 
@@ -32,7 +32,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void SummaryText()
         {
-            var tpXml = File.ReadAllText(@"TestData\mask-text.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "mask-text.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("ValueSet");
 
             var nav = new ScopedNode(getXmlNode(tpXml));
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void SummaryData()
         {
-            var tpXml = File.ReadAllText(@"TestData\mask-text.xml");
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "mask-text.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("ValueSet");
 
             var nav = new ScopedNode(getXmlNode(tpXml));

--- a/src/Hl7.Fhir.Specification.Tests/JTokenExtensionsTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/JTokenExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Specification.Tests
         private Newtonsoft.Json.Linq.JObject getPatientExample()
         {
             //var reader = new StringReader(Properties.TestResources.TestPatientJson);
-            var json = File.ReadAllText(@"TestData\TestPatient.json");
+            var json = File.ReadAllText(Path.Combine("TestData", "TestPatient.json"));
 
             return (JObject)JObject.Parse(json);
         }

--- a/src/Hl7.Fhir.Specification.Tests/JsonNavigatorTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/JsonNavigatorTests.cs
@@ -277,7 +277,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         private static JsonXPathNavigator buildNav()
         {
-            var json = File.ReadAllText(@"TestData\TestPatient.json");
+            var json = File.ReadAllText(Path.Combine("TestData", "TestPatient.json"));
             var reader = new StringReader(json);
             return new JsonXPathNavigator(new JsonTextReader(reader));
         }

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -15,6 +15,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using ssac = System.Security.AccessControl;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -71,6 +72,9 @@ namespace Hl7.Fhir.Specification.Tests
             var fourthRun = sw.ElapsedMilliseconds;
             Assert.IsTrue(fourthRun > secondRun);
 
+            // Something fishy going on here.
+            // if I do not wait before the statement File.SetLastWriteTimeUtc fa.IsActual returns true
+            Thread.Sleep(500);
             File.SetLastWriteTimeUtc(zipFile, DateTimeOffset.UtcNow.DateTime);
             Assert.IsFalse(fa.IsActual());
         }
@@ -284,7 +288,7 @@ namespace Hl7.Fhir.Specification.Tests
             var subPath3 = Path.Combine(testPath, "sub3");
             Directory.CreateDirectory(subPath3);
 
-            const string srcPath = @"TestData\snapshot-test\WMR\";
+            string srcPath = Path.Combine("TestData", "snapshot-test", "WMR");
             const string srcFile1 = "MyBasic.structuredefinition.xml";
             const string srcFile2 = "MyBundle.structuredefinition.xml";
 

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
@@ -18,10 +18,10 @@ namespace Hl7.Fhir.Specification.Tests
     {
 
         [TestMethod]
-        public void TestPatientXmlSummary() => TestPatientSummary(@"TestData\TestPatient.xml");
+        public void TestPatientXmlSummary() => TestPatientSummary(Path.Combine("TestData", "TestPatient.xml"));
 
         [TestMethod]
-        public void TestPatientJsonSummary() => TestPatientSummary(@"TestData\TestPatient.json");
+        public void TestPatientJsonSummary() => TestPatientSummary(Path.Combine("TestData", "TestPatient.json"));
 
         void TestPatientSummary(string path)
         {
@@ -31,11 +31,11 @@ namespace Hl7.Fhir.Specification.Tests
 
         [TestMethod]
         public void TestPatientXmlSummaryWithCustomHarvester()
-            => TestPatientSummaryWithCustomHarvester(@"TestData\TestPatient.xml", "Donald");
+            => TestPatientSummaryWithCustomHarvester(Path.Combine("TestData", "TestPatient.xml"), "Donald");
 
         [TestMethod]
         public void TestPatientJsonSummaryWithCustomHarvester()
-            => TestPatientSummaryWithCustomHarvester(@"TestData\TestPatient.json", "Chalmers");
+            => TestPatientSummaryWithCustomHarvester(Path.Combine("TestData", "TestPatient.json"), "Chalmers");
 
         void TestPatientSummaryWithCustomHarvester(string path, params string[] expectedNames)
         {
@@ -67,8 +67,8 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestValueSetXmlSummary()
         {
-            const string path = @"TestData\validation\SectionTitles.valueset.xml";
-            const string url = @"http://example.org/ValueSet/SectionTitles";
+            string path =  Path.Combine("TestData", "validation", "SectionTitles.valueset.xml");
+            const string url = "http://example.org/ValueSet/SectionTitles";
             var summary = assertSummary(path);
 
             // Common properties
@@ -88,8 +88,8 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestExtensionDefinitionSummary()
         {
-            const string path = @"TestData\snapshot-test\extensions\extension-us-core-religion.xml";
-            const string url = @"http://hl7.org/fhir/StructureDefinition/us-core-religion";
+            string path = Path.Combine("TestData", "snapshot-test", "extensions", "extension-us-core-religion.xml");
+            const string url = "http://hl7.org/fhir/StructureDefinition/us-core-religion";
             var summary = assertSummary(path);
 
             // Common properties
@@ -112,7 +112,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestProfilesTypesJson()
         {
-            const string path = @"TestData\profiles-types.json";
+            string path = Path.Combine("TestData", "profiles-types.json");
 
             var summaries = ArtifactSummaryGenerator.Default.Generate(path);
             Assert.IsNotNull(summaries);
@@ -158,7 +158,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestProfilesResourcesXml()
         {
-            const string path = @"TestData\profiles-resources.xml";
+            string path = Path.Combine("TestData", "profiles-resources.xml");
 
             var summaries = ArtifactSummaryGenerator.Default.Generate(path);
             Assert.IsNotNull(summaries);

--- a/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
@@ -184,15 +184,15 @@ namespace Hl7.Fhir.Specification.Tests
         public void TestIgnoreFilter()
         {
             var files = new[] {
-                @"c:\bla\",
-                @"c:\bla\file1.json",
-                @"c:\bla\file1.xml",
-                @"c:\bla\bla2\file1.json",
-                @"c:\bla\bla2\file2.xml",
-                @"c:\bla\bla2\text1.txt",
-                @"c:\bla\bla2\bla3\test2.jpg",
-                @"c:\blie\bla.xml" };
-            var basef = @"c:\bla";
+                Path.Combine("c:", "bla"),
+                Path.Combine("c:", "bla", "file1.json"),
+                Path.Combine("c:", "bla", "file1.xml"),
+                Path.Combine("c:", "bla", "bla2", "file1.json"),
+                Path.Combine("c:", "bla", "bla2", "file2.xml"),
+                Path.Combine("c:", "bla", "bla2", "text1.txt"),
+                Path.Combine("c:", "bla", "bla2", "bla3", "test2.jpg"),
+                Path.Combine("c:", "blie", "bla.xml") };
+            var basef = Path.Combine("c:", "bla");
 
             // Basic glob filter
             var fi = new FilePatternFilter("*.xml");
@@ -204,7 +204,7 @@ namespace Hl7.Fhir.Specification.Tests
             // Absolute select 1 file
             fi = new FilePatternFilter("/file1.json");
             r = fi.Filter(basef, files);
-            Assert.AreEqual(@"c:\bla\file1.json", r.Single());
+            Assert.AreEqual(Path.Combine("c:", "bla", "file1.json"), r.Single());
 
             // Absolute select 1 file - no match
             fi = new FilePatternFilter("/file1.crap");
@@ -215,7 +215,7 @@ namespace Hl7.Fhir.Specification.Tests
             fi = new FilePatternFilter("/*.json");
             r = fi.Filter(basef, files);
             Assert.AreEqual(1, r.Count());
-            Assert.AreEqual(@"c:\bla\file1.json", r.Single());
+            Assert.AreEqual(Path.Combine("c:", "bla", "file1.json"), r.Single());
 
             // Relative select file
             fi = new FilePatternFilter("file1.json");
@@ -233,37 +233,37 @@ namespace Hl7.Fhir.Specification.Tests
             fi = new FilePatternFilter("**/file1.*");
             r = fi.Filter(basef, files);
             Assert.AreEqual(3, r.Count());
-            Assert.IsTrue(r.All(f => f.Contains("\\file1.")));
+            Assert.IsTrue(r.All(f => f.Contains($"{Path.DirectorySeparatorChar}file1.")));
 
             // Relative select file with glob
             fi = new FilePatternFilter("**/*.txt");
             r = fi.Filter(basef, files);
             Assert.AreEqual(1, r.Count());
-            Assert.AreEqual(@"c:\bla\bla2\text1.txt", r.Single());
+            Assert.AreEqual(Path.Combine("c:", "bla", "bla2", "text1.txt"), r.Single());
 
             // Relative select file with glob
             fi = new FilePatternFilter("**/file*.xml");
             r = fi.Filter(basef, files);
             Assert.AreEqual(2, r.Count());
-            Assert.IsTrue(r.All(f => f.Contains("\\file") && f.EndsWith(".xml")));
+            Assert.IsTrue(r.All(f => f.Contains($"{Path.DirectorySeparatorChar}file") && f.EndsWith(".xml")));
 
             // Relative select file with glob
             fi = new FilePatternFilter("file1.*");
             r = fi.Filter(basef, files);
             Assert.AreEqual(3, r.Count());
-            Assert.IsTrue(r.All(f => f.Contains("\\file1.")));
+            Assert.IsTrue(r.All(f => f.Contains($"{Path.DirectorySeparatorChar}file1.")));
 
             // Select whole directory
             fi = new FilePatternFilter("bla2/");
             r = fi.Filter(basef, files);
             Assert.AreEqual(4, r.Count());
-            Assert.IsTrue(r.All(f => f.Contains("\\bla2\\")));
+            Assert.IsTrue(r.All(f => f.Contains($"{Path.DirectorySeparatorChar}bla2{Path.DirectorySeparatorChar}")));
 
             // Select whole directory
             fi = new FilePatternFilter("bla2/**");
             r = fi.Filter(basef, files);
             Assert.AreEqual(4, r.Count());
-            Assert.IsTrue(r.All(f => f.Contains("\\bla2\\")));
+            Assert.IsTrue(r.All(f => f.Contains($"{Path.DirectorySeparatorChar}bla2{Path.DirectorySeparatorChar}")));
 
             // Select whole directory
             fi = new FilePatternFilter("/bla3/");
@@ -274,13 +274,13 @@ namespace Hl7.Fhir.Specification.Tests
             fi = new FilePatternFilter("/bla2/*/*.jpg");
             r = fi.Filter(basef, files);
             Assert.AreEqual(1, r.Count());
-            Assert.AreEqual(@"c:\bla\bla2\bla3\test2.jpg", r.Single());
+            Assert.AreEqual(Path.Combine("c:", "bla", "bla2", "bla3", "test2.jpg"), r.Single());
 
             // Case-insensitive
             fi = new FilePatternFilter("TEST2.jpg");
             r = fi.Filter(basef, files);
             Assert.AreEqual(1, r.Count());
-            Assert.AreEqual(@"c:\bla\bla2\bla3\test2.jpg", r.Single());
+            Assert.AreEqual(Path.Combine("c:", "bla", "bla2", "bla3", "test2.jpg"), r.Single());
         }
 
 

--- a/src/Hl7.Fhir.Specification.Tests/Source/ResourceResolverTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ResourceResolverTests.cs
@@ -49,7 +49,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            var dirSource = new DirectorySource(@"TestData\validation");
+            var dirSource = new DirectorySource(Path.Combine("TestData", "validation"));
             extDefn = dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0");
 
             Assert.ThrowsException<ArgumentException>(() => dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0|"));

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -42,8 +42,8 @@ namespace Hl7.Fhir.Specification.Tests
 
         //    _source = new CachedResolver(
         //        new MultiResolver(
-        //            new BundleExampleResolver(@"TestData\validation"),
-        //            new DirectorySource(@"TestData\validation"),
+        //            new BundleExampleResolver(Path.Combine("TestData", "validation")),
+        //            new DirectorySource(Path.Combine("TestData", "validation")),
         //            new TestProfileArtifactSource(),
         //            new ZipSource("specification.zip")));
 
@@ -406,7 +406,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void ValidateOverNameRef()
         {
-            var questionnaireXml = File.ReadAllText("TestData\\validation\\questionnaire-sdc-profile-example-cap.xml");
+            var questionnaireXml = File.ReadAllText(Path.Combine("TestData", "validation", "questionnaire-sdc-profile-example-cap.xml"));
 
             var questionnaire = (new FhirXmlParser()).Parse<Questionnaire>(questionnaireXml);
             Assert.NotNull(questionnaire);
@@ -461,7 +461,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void ValidateContained()
         {
-            var careplanXml = File.ReadAllText("TestData\\validation\\careplan-example-integrated.xml");
+            var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
 
             var careplan = (new FhirXmlParser()).Parse<CarePlan>(careplanXml);
             Assert.NotNull(careplan);
@@ -477,7 +477,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void MeasureDeepCopyPerformance()
         {
-            var questionnaireXml = File.ReadAllText("TestData\\validation\\questionnaire-sdc-profile-example-cap.xml");
+            var questionnaireXml = File.ReadAllText(Path.Combine("TestData", "validation", "questionnaire-sdc-profile-example-cap.xml"));
 
             var questionnaire = (new FhirXmlParser()).Parse<Questionnaire>(questionnaireXml);
             Assert.NotNull(questionnaire);
@@ -526,7 +526,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void ValidateBundle()
         {
-            var bundleXml = File.ReadAllText("TestData\\validation\\bundle-contained-references.xml");
+            var bundleXml = File.ReadAllText(Path.Combine("TestData", "validation", "bundle-contained-references.xml"));
 
             var bundle = (new FhirXmlParser()).Parse<Bundle>(bundleXml);
             Assert.NotNull(bundle);
@@ -566,7 +566,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void RunXsdValidation()
         {
-            var careplanXml = File.ReadAllText("TestData\\validation\\careplan-example-integrated.xml");
+            var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
             var cpDoc = XDocument.Parse(careplanXml, LoadOptions.SetLineInfo);
 
             var report = _validator.Validate(cpDoc.CreateReader());
@@ -637,7 +637,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void ValidateExtensionExamples()
         {
-            var levinXml = File.ReadAllText(@"TestData\validation\Levin.patient.xml");
+            var levinXml = File.ReadAllText(Path.Combine("TestData", "validation", "Levin.patient.xml"));
             var levin = (new FhirXmlParser()).Parse<Patient>(levinXml);
             DebugDumpOutputXml(levin);
             Assert.NotNull(levin);
@@ -691,7 +691,7 @@ namespace Hl7.Fhir.Specification.Tests
             public Resource ResolveByUri(string uri)
             {
                 ResourceIdentity reference = new ResourceIdentity(uri);
-                var filename = $"{reference.Id}.{reference.ResourceType}.xml";
+                var filename = $"{reference.Id}.{reference.ResourceType.ToLower()}.xml";
                 var path = Path.Combine(_path, filename);
 
                 if (File.Exists(path))
@@ -737,15 +737,15 @@ namespace Hl7.Fhir.Specification.Tests
         public void TestPatientWithOrganization()
         {
             // DirectorySource (and ResourceStreamScanner) does not support json...
-            // var source = new DirectorySource(@"TestData\validation");
+            // var source = new DirectorySource(Path.Combine("TestData", "validation"));
             // var res = source.ResolveByUri("Patient/pat1"); // cf. "Patient/Levin"
 
-            var jsonPatient = File.ReadAllText(@"TestData\validation\patient-ck.json");
+            var jsonPatient = File.ReadAllText(Path.Combine("TestData", "validation", "patient-ck.json"));
             var parser = new FhirJsonParser();
             var patient = parser.Parse<Patient>(jsonPatient);
             Assert.NotNull(patient);
 
-            var jsonOrganization = File.ReadAllText(@"TestData\validation\organization-ck.json");
+            var jsonOrganization = File.ReadAllText(Path.Combine("TestData", "validation", "organization-ck.json"));
             var organization = parser.Parse<Organization>(jsonOrganization);
             Assert.NotNull(organization);
 
@@ -765,8 +765,8 @@ namespace Hl7.Fhir.Specification.Tests
                 // This will force the validator to regenerate all snapshots
                 new ClearSnapshotResolver(
                     new MultiResolver(
-                        // new BundleExampleResolver(@"TestData\validation"),
-                        // new DirectorySource(@"TestData\validation"),
+                        // new BundleExampleResolver(Path.Combine("TestData", "validation")),
+                        // new DirectorySource(Path.Combine("TestData", "validation")),
                         // new TestProfileArtifactSource(),
                         memResolver,
                         new ZipSource("specification.zip"))));
@@ -801,7 +801,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void ValidateInternalReferenceWithinContainedResources()
         {
-            var obsOverview = File.ReadAllText(@"TestData\validation\observation-list.xml");
+            var obsOverview = File.ReadAllText(Path.Combine("TestData", "validation", "observation-list.xml"));
             var parser = new FhirXmlParser();
 
             var obsList = parser.Parse<List>(obsOverview);
@@ -833,7 +833,7 @@ namespace Hl7.Fhir.Specification.Tests
                 });
             buffer.LinkTo(processor, new DataflowLinkOptions { PropagateCompletion = true });
 
-            var careplanXml = File.ReadAllText(@"TestData\validation\careplan-example-integrated.xml");
+            var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
             var cpDoc = XDocument.Parse(careplanXml, LoadOptions.SetLineInfo);
 
             for (int i = 0; i < nrOfParrallelTasks; i++)

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,8 +20,8 @@ namespace Hl7.Fhir.Specification.Tests
         {
             Resolver = new CachedResolver(
                     new MultiResolver(
-                        new BasicValidationTests.BundleExampleResolver(@"TestData\validation"),
-                        new DirectorySource(@"TestData\validation"),
+                        new BasicValidationTests.BundleExampleResolver(Path.Combine("TestData", "validation")),
+                        new DirectorySource(Path.Combine("TestData", "validation")),
                         new TestProfileArtifactSource(),
                         new ZipSource("specification.zip")));
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/SchemaCollectionTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/SchemaCollectionTest.cs
@@ -54,7 +54,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestSchemaCollectionValidation()
         {
-            var s = File.ReadAllText(@"TestData\TestPatient.xml");
+            var s = File.ReadAllText(Path.Combine("TestData", "TestPatient.xml"));
             var doc = SerializationUtil.XDocumentFromXmlText(s);
 
             string message = null;

--- a/src/Hl7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
+++ b/src/Hl7.FhirPath.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
@@ -211,7 +211,7 @@ namespace Hl7.FhirPath.Tests
 
                 // Now perform this unit test
                 Model.DomainResource resource = null;
-                string basepath = Path.Combine(TestData.GetTestDataBasePath(), @"fhirpath\input");
+                string basepath = Path.Combine(TestData.GetTestDataBasePath(), "fhirpath", "input");
 
                 if (!_cache.ContainsKey(inputfile))
                 {
@@ -330,7 +330,7 @@ namespace Hl7.FhirPath.Tests
         public void testExtensionDefinitions()
         {
             // obsolete:
-            // Bundle b = (Bundle)FhirParser.ParseResourceFromXml(File.ReadAllText("TestData\\extension-definitions.xml"));
+            // Bundle b = (Bundle)FhirParser.ParseResourceFromXml(File.ReadAllText(Path.Combine(TestData", "extension-definitions.xml")));
             var parser = new FhirXmlParser();
             Model.Bundle b = parser.Parse<Model.Bundle>(TestData.ReadTextFile("extension-definitions.xml"));
 

--- a/src/fhir-net-api.targets
+++ b/src/fhir-net-api.targets
@@ -9,6 +9,7 @@
     <Copy SourceFiles="$(OutputPath)$(PackageId).$(PackageVersion).symbols.nupkg" DestinationFolder="$(PackageOutputDirectory)" />
   </Target>
 -->
+
     <Choose>  
         <When Condition="$(APPVEYOR)=='True' ">
           <PropertyGroup>
@@ -16,12 +17,14 @@
             <TestCaseFilter>/TestCaseFilter:"TestCategory!=IntegrationTest&amp;TestCategory!=FhirClient"</TestCaseFilter>
           </PropertyGroup>
         </When>
+        <!--
         <Otherwise>
           <PropertyGroup>
             <VSTestLogger>/logger:Console</VSTestLogger>
             <TestCaseFilter />
           </PropertyGroup>
         </Otherwise>
+        -->
     </Choose>
 
   <Target Name="VSTest" DependsOnTargets="Build" Condition="$(ContainsTests) == 'true'">


### PR DESCRIPTION
This PR is probably in the nice to have section, it enables the tests to run on a Linux-based OS, as well as Windows. It should also work on Mac OS X, but I haven't tested it on OS X yet.

There are a few things here that I am not quite happy with.

1. In src/fhir-net-api.targets I have commented out the Otherwise section for VSTestLogger, since I was not able to get a proper listing of the tests in vscode. Not sure if this has any other implications like the build process or anything?
2. ~~In .gitattributes line endings are now `lf` for *.xml and *.json independently of platform, tried back and forth between `crlf` and `lf`, but `lf` was what ended up working on both Linux and Windows~~
3. Added a Thread.Sleep in ArtifactSourceTests::ZipCacherShouldCache at line 77.  Not sure what is going on, and it still fails sometimes on Linux, but if I do not wait before the statement File.SetLastWriteTimeUtc fa.IsActual always returns true and the test fails.

I added these settings in .vscode/settings.json to get the test runner in vscode run properly + only run the unit tests:
```
{
    "dotnet-test-explorer.testProjectPath": "**/*Tests.csproj",
    "dotnet-test-explorer.testArguments": "--filter TestCategory!=IntegrationTest"
}
```


Commit summary:
* Basically changed all paths that had a hard-coded separator to use
  Path.Combine instead
* Removed the Otherwise section in fhir-net.api.targets since
  /logger:Console does not give the appropriate output to i.e. list the
  tests in the .NET Test Explorer in vscode
* Added a Thread.Sleep in ArtifactSourceTests::ZipCacherShouldCache at
  line 77. See comment for details, not sure what is going on, but it
  seems that it hasn't solved the actual problem since it sometimes
  works, while other times will fail.
* ~~eol always lf for .xml and .json. If not the navigator compare
  examples where 'expected' input is xml and  'actual' input is json will
  fail. This is because strings in json cannot contain line breaks
  whereas in xml they can.~~