### PR TITLE
#821: Improved error reporting by always mentioning the context of the error

### DIFF
--- a/src/Hl7.Fhir.Core/ElementModel/PocoBuilder.cs
+++ b/src/Hl7.Fhir.Core/ElementModel/PocoBuilder.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Serialization
                 if (typeFound == null)
                 {
                     ExceptionNotification.Error(
-                        new StructuralTypeException($"The .NET type '{dataType.Name}' does not represent a FHIR type."));
+                        new StructuralTypeException($"While building a POCO: The .NET type '{dataType.Name}' does not represent a FHIR type."));
 
                     return null;
                 }
@@ -107,7 +107,7 @@ namespace Hl7.Fhir.Serialization
                 {
                     ExceptionHandler.NotifyOrThrow(this,
                         ExceptionNotification.Error(
-                            new StructuralTypeException($"There is no .NET type representing the FHIR type '{source.InstanceType}'.")));
+                            new StructuralTypeException($"While building a POCO: There is no .NET type representing the FHIR type '{source.InstanceType}'.")));
 
                     return null;
                 }

--- a/src/Hl7.Fhir.Core/Serialization/ComplexTypeReader.cs
+++ b/src/Hl7.Fhir.Core/Serialization/ComplexTypeReader.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (c) 2014, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -62,9 +62,14 @@ namespace Hl7.Fhir.Serialization
             var mapping = _inspector.FindClassMappingByType(_current.InstanceType);
 
             if (mapping == null)
-                throw Error.Format("Asked to deserialize unknown type '" + _current.InstanceType + "'", _current.Location);
+                RaiseFormatError($"Asked to deserialize unknown type '{_current.InstanceType}'", _current.Location);
 
             return Deserialize(mapping, existing);
+        }
+
+        internal static void RaiseFormatError(string message, string location)
+        {
+            throw Error.Format("While building a POCO: " + message, location);
         }
 
         internal Base Deserialize(ClassMapping mapping, Base existing = null)
@@ -125,7 +130,7 @@ namespace Hl7.Fhir.Serialization
                         value = mappedProperty.GetValue(existing);
 
                         if (value != null && !mappedProperty.IsCollection)
-                            throw Error.Format($"Element '{mappedProperty.Name}' must not repeat", memberData.Location);
+                            RaiseFormatError($"Element '{mappedProperty.Name}' must not repeat", memberData.Location);
                     }
 
                     var reader = new DispatchingReader(memberData, Settings, arrayMode: false);
@@ -141,7 +146,7 @@ namespace Hl7.Fhir.Serialization
                         if (!Settings.AllowUnrecognizedEnums)
                         {
                             if (EnumUtility.ParseLiteral((string)value, mappedProperty.ImplementingType) == null)
-                                throw Error.Format("Literal '{0}' is not a valid value for enumeration '{1}'".FormatWith(value, mappedProperty.ImplementingType.Name), _current.Location);
+                                RaiseFormatError($"Literal '{value}' is not a valid value for enumeration '{mappedProperty.ImplementingType.Name}'", _current.Location);
                         }
 
                         ((Primitive)existing).ObjectValue = value;
@@ -157,7 +162,7 @@ namespace Hl7.Fhir.Serialization
                 else
                 {
                     if (Settings.AcceptUnknownMembers == false)
-                        throw Error.Format("Encountered unknown member '{0}' while de-serializing".FormatWith(memberName), memberData.Location);
+                        RaiseFormatError($"Encountered unknown member '{memberName}' while de-serializing", memberData.Location);
                     else
                         Message.Info("Skipping unknown member " + memberName);
                 }

--- a/src/Hl7.Fhir.Core/Serialization/DispatchingReader.cs
+++ b/src/Hl7.Fhir.Core/Serialization/DispatchingReader.cs
@@ -7,14 +7,7 @@
  */
 
 using Hl7.Fhir.Introspection;
-using Hl7.Fhir.Support;
-using Newtonsoft.Json.Linq;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using Hl7.Fhir.ElementModel;
@@ -72,7 +65,8 @@ namespace Hl7.Fhir.Serialization
             }
 
             if (_current.InstanceType is null)
-                throw Error.Format("Underlying data source was not able to provide the actual instance type of the resource.");
+                ComplexTypeReader.RaiseFormatError(
+                    "Underlying data source was not able to provide the actual instance type of the resource.", _current.Location);
 
             ClassMapping mapping = prop.Choice == ChoiceType.DatatypeChoice
                 ? getMappingForType(prop, memberName, _current.InstanceType)
@@ -95,7 +89,8 @@ namespace Hl7.Fhir.Serialization
             result = _inspector.FindClassMappingForFhirDataType(typeName);
 
             if (result == null)
-                throw Error.Format("Encountered polymorph member {0}, which uses unknown datatype {1}".FormatWith(memberName, typeName), _current.Location);
+                ComplexTypeReader.RaiseFormatError(
+                    $"Encountered polymorph member {memberName}, which uses unknown datatype {typeName}", _current.Location);
 
             return result;
         }

--- a/src/Hl7.Fhir.Core/Serialization/PrimitiveValueReader.cs
+++ b/src/Hl7.Fhir.Core/Serialization/PrimitiveValueReader.cs
@@ -46,7 +46,8 @@ namespace Hl7.Fhir.Serialization
             catch (NotSupportedException exc)
             {
                 // thrown when an unsupported conversion was required
-                throw Error.Format(exc.Message, _current.Location);
+                ComplexTypeReader.RaiseFormatError("Not supported - " + exc.Message, _current.Location);
+                throw;  // just to satisfy the compiler - RaiseFormatError throws.
             }
         }
     }

--- a/src/Hl7.Fhir.Core/Serialization/ResourceReader.cs
+++ b/src/Hl7.Fhir.Core/Serialization/ResourceReader.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (c) 2014, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -40,12 +40,13 @@ namespace Hl7.Fhir.Serialization
         public Resource Deserialize(Resource existing=null)
         {
             if(_reader.InstanceType is null)
-                throw Error.Format("Underlying data source was not able to provide the actual instance type of the resource.");
+                ComplexTypeReader.RaiseFormatError(
+                    "Underlying data source was not able to provide the actual instance type of the resource.", _reader.Location);
 
             var mapping = _inspector.FindClassMappingForResource(_reader.InstanceType);
 
             if (mapping == null)
-                throw Error.Format("Asked to deserialize unknown resource '" + _reader.InstanceType + "'", _reader.Location);
+                ComplexTypeReader.RaiseFormatError($"Asked to deserialize unknown resource '{_reader.InstanceType}'", _reader.Location);
              
             // Delegate the actual work to the ComplexTypeReader, since
             // the serialization of Resources and ComplexTypes are virtually the same

--- a/src/Hl7.Fhir.ElementModel/TypedElementNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementNode.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.ElementModel
 
         private void raiseTypeError(string message, object source, bool warning = false)
         {
-            var exc = new StructuralTypeException(message);
+            var exc = new StructuralTypeException("Type checking the data: " + message);
             var notification = warning ?
                 ExceptionNotification.Warning(exc) :
                 ExceptionNotification.Error(exc);

--- a/src/Hl7.Fhir.Serialization/FhirJsonNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonNode.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (c) 2018, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -311,7 +311,7 @@ namespace Hl7.Fhir.Serialization
         private void raiseFormatError(string message, JToken node)
         {
             var (lineNumber, linePosition) = getPosition(node);
-            ExceptionHandler.NotifyOrThrow(this, ExceptionNotification.Error(Error.Format(message, lineNumber, linePosition)));
+            ExceptionHandler.NotifyOrThrow(this, ExceptionNotification.Error(Error.Format("Parser: " + message, lineNumber, linePosition)));
         }
 
         private (int lineNumber, int linePosition) getPosition(JToken node) => 
@@ -389,7 +389,7 @@ namespace Hl7.Fhir.Serialization
 
                 if (sdSummary.IsCollection && serializationDetails.ArrayIndex == null)
                     ies.ExceptionHandler.NotifyOrThrow(nav, ExceptionNotification.Error(
-                        new StructuralTypeException($"Since element '{nav.Name}' repeats, an array must be used here.")));
+                        new StructuralTypeException($"Parser: Since element '{nav.Name}' repeats, an array must be used here.")));
 
                 if (!sdSummary.IsCollection && serializationDetails.ArrayIndex != null)
                 {
@@ -397,7 +397,7 @@ namespace Hl7.Fhir.Serialization
                     if (serializationDetails.ArrayIndex == 0)
                     {
                         ies.ExceptionHandler.NotifyOrThrow(nav, ExceptionNotification.Error(
-                            new StructuralTypeException($"Element '{nav.Name}' does not repeat, so an array must not be used here.")));
+                            new StructuralTypeException($"Parser: Element '{nav.Name}' does not repeat, so an array must not be used here.")));
                     }
                 }
 


### PR DESCRIPTION
One of the causes of #821 was that it was unclear to the developer what the context of error messages was: are we parsing, serializing, type checking etc. Have now added that context on all components of the parse/type/serialize pipeline