### PR TITLE
fix: change the technical license structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018, HL7, Firely (info@fire.ly), Microsoft Open Technologies 
+Copyright (c) 2013-2019, HL7, Firely (info@fire.ly), Microsoft Open Technologies 
 and contributors. See the file CONTRIBUTORS for details
 
 All rights reserved.

--- a/src/fhir-net-api.props
+++ b/src/fhir-net-api.props
@@ -6,15 +6,19 @@
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Ewout Kramer (ewout@fire.ly) and contributors</Authors>
     <Company>Firely (https://fire.ly)</Company>
-    <Copyright>Copyright 2019 Firely.  Contains materials (C) HL7 International</Copyright>
+    <Copyright>Copyright 2013-2019 Firely.  Contains materials (C) HL7 International</Copyright>
     <PackageProjectUrl>https://github.com/ewoutkramer/fhir-net-api</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ewoutkramer/fhir-net-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIconUrl>https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/master/icon-fhir-32.png</PackageIconUrl>
     <PackageReleaseNotes>See http://docs.simplifier.net/fhirnetapi/releasenotes.html</PackageReleaseNotes>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/ewoutkramer/fhir-net-api/develop/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RunFhirPathTests>true</RunFhirPathTests> <!-- Used for CI/CD pipelines -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <!-- Although netstandard1.1 support codegen using the Expression class, we need at least
   one version of our library that does not require it, since iOS does not have support for it.


### PR DESCRIPTION
Change the technical license structure in the solution to meet the nuget requirements. Also update the year in the copyright statement.