### PR TITLE
fix: Validation of References to contained resources where there are multiple potential types, See also PR #829

### DIFF
--- a/src/Hl7.Fhir.Core/Model/ElementDefinitionExtensions.cs
+++ b/src/Hl7.Fhir.Core/Model/ElementDefinitionExtensions.cs
@@ -40,7 +40,7 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OfType(this ElementDefinition ed, FHIRAllTypes type, string profile=null)
+        public static ElementDefinition OfType(this ElementDefinition ed, FHIRAllTypes type, string[] profile=null)
         {
             ed.Type.Clear();
             ed.OrType(type, profile);
@@ -48,7 +48,7 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OfReference(this ElementDefinition ed, string targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string profile=null)
+        public static ElementDefinition OfReference(this ElementDefinition ed, string[] targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string[] profile=null)
         {
             ed.Type.Clear();
             ed.OrReference(targetProfile, aggregation, profile);
@@ -56,16 +56,19 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OrType(this ElementDefinition ed, FHIRAllTypes type, string profile = null)
+        public static ElementDefinition OrType(this ElementDefinition ed, FHIRAllTypes type, string[] profiles = null)
         {
             if (type == FHIRAllTypes.Reference)
                 throw Error.InvalidOperation("Use OfReference/OrReference instead of OfType/OrType for references");
 
             var newType = new ElementDefinition.TypeRefComponent { Code = type.GetLiteral() };
-            if (profile != null)
+
+            if (profiles != null)
             {
-                // TODO: BRIAN: Should this be TargetProfile for the reference?
-                newType.ProfileElement.Add(new Canonical(profile));
+                foreach (var profile in profiles)
+                {
+                    newType.ProfileElement.Add(new Canonical(profile));
+                }
             }
 
             ed.Type.Add(newType);
@@ -73,14 +76,24 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OrReference(this ElementDefinition ed, string targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string profile = null)
+        public static ElementDefinition OrReference(this ElementDefinition ed, string[] targetProfiles, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string[] profiles = null)
         {
             var newType = new ElementDefinition.TypeRefComponent { Code = FHIRAllTypes.Reference.GetLiteral() };
 
-            if (targetProfile != null)
-                newType.TargetProfileElement.Add(new Canonical(targetProfile));
-            if (profile != null)
-                newType.ProfileElement.Add(new Canonical(profile));
+            if (targetProfiles != null)
+            {
+                foreach (var targetProfile in targetProfiles)
+                {
+                    newType.TargetProfileElement.Add(new Canonical(targetProfile));
+                }
+            }
+            if (profiles != null)
+            {
+                foreach (var profile in profiles)
+                {
+                    newType.ProfileElement.Add(new Canonical(profile));
+                }
+            }
             if (aggregation != null) newType.Aggregation = aggregation.Cast<ElementDefinition.AggregationMode?>();
 
             ed.Type.Add(newType);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -84,8 +84,7 @@ namespace Hl7.Fhir.Validation
 
             cons.Add(new ElementDefinition("Patient").OfType(FHIRAllTypes.Patient));
             cons.Add(new ElementDefinition("Patient.identifier").Required(max: "*")
-                        .OfType(FHIRAllTypes.Identifier, "http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN")
-                        .OrType(FHIRAllTypes.Identifier, "http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL"));
+                        .OfType(FHIRAllTypes.Identifier, new[] { "http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN", "http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL" }));
 
             return result;
         }
@@ -168,8 +167,7 @@ namespace Hl7.Fhir.Validation
 
             cons.Add(new ElementDefinition("Observation").OfType(FHIRAllTypes.Observation));
             cons.Add(new ElementDefinition("Observation.value[x]")
-                .OfType(FHIRAllTypes.Quantity, "http://validationtest.org/fhir/StructureDefinition/WeightQuantity")
-                .OrType(FHIRAllTypes.Quantity, "http://validationtest.org/fhir/StructureDefinition/HeightQuantity")
+                .OfType(FHIRAllTypes.Quantity,new[] { "http://validationtest.org/fhir/StructureDefinition/WeightQuantity", "http://validationtest.org/fhir/StructureDefinition/HeightQuantity" })
                 .OrType(FHIRAllTypes.String));
 
             Debug.WriteLine(new FhirXmlSerializer().SerializeToString(result));
@@ -187,7 +185,7 @@ namespace Hl7.Fhir.Validation
             cons.Add(new ElementDefinition("Bundle").OfType(FHIRAllTypes.Bundle));
             cons.Add(new ElementDefinition("Bundle.entry.resource")
                 .OfType(FHIRAllTypes.Organization)
-                .OrType(FHIRAllTypes.Patient, $"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization"));
+                .OrType(FHIRAllTypes.Patient, new[] { $"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization" }));
 
             return result;
         }
@@ -216,7 +214,7 @@ namespace Hl7.Fhir.Validation
 
             cons.Add(new ElementDefinition("Patient").OfType(FHIRAllTypes.Patient));
             cons.Add(new ElementDefinition("Patient.managingOrganization")
-                .OfReference(ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Organization), aggregation));
+                .OfReference(new[] { (string)ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Organization) }, aggregation));
 
             return result;
         }

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefExtensions.cs
@@ -19,15 +19,15 @@ namespace Hl7.Fhir.Validation
     {
         public static string ReadableName(this StructureDefinition sd) => sd.Derivation == StructureDefinition.TypeDerivationRule.Constraint ? sd.Url : sd.Id;
 
-        public static string GetDeclaredProfiles(this ElementDefinition.TypeRefComponent typeRef)
+        public static string[] GetDeclaredProfiles(this ElementDefinition.TypeRefComponent typeRef)
         {
             // back to what DSTU2 had ;)
             if (typeRef.ProfileElement.Any())
             {
-                return typeRef.Profile.First();
+                return typeRef.Profile.ToArray();
             }
             if (!string.IsNullOrEmpty(typeRef.Code))
-                return ModelInfo.CanonicalUriForFhirCoreType(typeRef.Code);
+                return new[] { ModelInfo.CanonicalUriForFhirCoreType(typeRef.Code)?.Value };
             return null;
         }
 

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -99,13 +99,24 @@ namespace Hl7.Fhir.Validation
             OperationOutcome validate()
             {
                 // First, call Validate() for the current element (the reference itself) against the profile
-                var result = validator.Validate(instance, tr.GetDeclaredProfiles(), statedCanonicals: null, statedProfiles: null);
+                var validations = tr.GetDeclaredProfiles()?.Select(profile => createValidatorForDeclaredProfile(validator, instance, profile));
+                var result = validator.Combine(BatchValidationMode.Any, instance, validations);
 
                 // If this is a reference, also validate the reference against the targetProfile
                 if (ModelInfo.FhirTypeNameToFhirType(tr.Code) == FHIRAllTypes.Reference)
                     result.Add( validator.ValidateResourceReference(instance, tr) );
 
                 return result;
+            }
+        }
+
+        private static Func<OperationOutcome> createValidatorForDeclaredProfile(Validator validator, ScopedNode instance, string declaredProfile)
+        {
+            return validate; 
+
+            OperationOutcome validate()
+            {
+                return validator.Validate(instance, declaredProfile, statedCanonicals: null, statedProfiles: null);
             }
         }
 
@@ -162,12 +173,12 @@ namespace Hl7.Fhir.Validation
                 //              we be permitting more than one target profile here.
                 if (encounteredKind != ElementDefinition.AggregationMode.Referenced)
                 {
-                    childResult = validator.Validate(referencedResource, typeRef.TargetProfile.FirstOrDefault(), statedProfiles: null, statedCanonicals: null);
+                    childResult = validator.ValidateReferences(referencedResource, typeRef.TargetProfile);
                 }
                 else
                 {
                     var newValidator = validator.NewInstance();
-                    childResult = newValidator.Validate(referencedResource, typeRef.TargetProfile.FirstOrDefault(), statedProfiles: null, statedCanonicals: null);
+                    childResult = newValidator.ValidateReferences(referencedResource, typeRef.TargetProfile);
                 }
 
                 // Prefix each path with the referring resource's path to keep the locations
@@ -181,6 +192,21 @@ namespace Hl7.Fhir.Validation
                 validator.Trace(outcome, $"Cannot resolve reference {reference}", Issue.UNAVAILABLE_REFERENCED_RESOURCE, instance);
 
             return outcome;
+        }
+
+       
+        private static OperationOutcome ValidateReferences(this Validator validator, ITypedElement referencedResource, IEnumerable<string> targetProfiles)
+        {
+            IEnumerable<Func<OperationOutcome>> validations = targetProfiles.Select(tp => createValidatorForReferenceResource(tp));
+            return validator.Combine(BatchValidationMode.Any, referencedResource, validations);
+
+            Func<OperationOutcome> createValidatorForReferenceResource(string targetProfile)
+            {
+                return () =>
+                {
+                    return validator.Validate(referencedResource, targetProfile, statedProfiles: null, statedCanonicals: null);
+                };
+            }
         }
 
         private static ITypedElement resolveReference(this Validator validator, ScopedNode instance, string reference, out ElementDefinition.AggregationMode? referenceKind, OperationOutcome outcome)


### PR DESCRIPTION
Validation of References to contained resources where there are multiple potential types, and the contained resource is not the first one targeted. 

Original in PR #829 of @brianpos