### PR TITLE
Allow now also Exponents in de primitive type decimal

### DIFF
--- a/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
+++ b/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
@@ -13,11 +13,14 @@ using Hl7.Fhir.Model.Primitives;
 using Hl7.Fhir.Support.Model;
 using System.Numerics;
 using System.Globalization;
+using System.Linq;
 
 namespace Hl7.Fhir.Serialization
 {
     public static class PrimitiveTypeConverter
     {
+        static readonly string[] FORBIDDEN_DECIMAL_PREFIXES = new[] { "+", ".", "00" };
+
         public static object FromSerializedValue(string value, string primitiveType)
         {
             var type = Primitives.GetNativeRepresentation(primitiveType);
@@ -122,7 +125,7 @@ namespace Hl7.Fhir.Serialization
                 return ConvertToDatetimeOffset(value).UtcDateTime;  // Obsolete: use DateTimeOffset instead!!
             if (typeof(Decimal) == to)
             {
-                if (Array.Exists(new[] { "+", ".", "00" }, c => value.StartsWith(c)) || value.EndsWith("."))
+                if (FORBIDDEN_DECIMAL_PREFIXES.Any(prefix => value.StartsWith(prefix)) || value.EndsWith("."))
                 {
                     // decimal cannot start with '+', '-' or '00' and cannot end with '-'
                     throw new FormatException("Input string was not in a correct format.");

--- a/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
+++ b/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
@@ -19,7 +19,7 @@ namespace Hl7.Fhir.Serialization
 {
     public static class PrimitiveTypeConverter
     {
-        static readonly string[] FORBIDDEN_DECIMAL_PREFIXES = new[] { "+", ".", "00" };
+        private static readonly string[] FORBIDDEN_DECIMAL_PREFIXES = new[] { "+", ".", "00" };
 
         public static object FromSerializedValue(string value, string primitiveType)
         {
@@ -127,7 +127,7 @@ namespace Hl7.Fhir.Serialization
             {
                 if (FORBIDDEN_DECIMAL_PREFIXES.Any(prefix => value.StartsWith(prefix)) || value.EndsWith("."))
                 {
-                    // decimal cannot start with '+', '-' or '00' and cannot end with '-'
+                    // decimal cannot start with '+', '-' or '00' and cannot end with '.'
                     throw new FormatException("Input string was not in a correct format.");
                 }
                 return decimal.Parse(value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);

--- a/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
+++ b/src/Hl7.Fhir.Support/Serialization/PrimitiveTypeConverter.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Utility;
 using Hl7.Fhir.Model.Primitives;
 using Hl7.Fhir.Support.Model;
 using System.Numerics;
+using System.Globalization;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -120,7 +121,14 @@ namespace Hl7.Fhir.Serialization
             if (typeof(DateTime) == to)
                 return ConvertToDatetimeOffset(value).UtcDateTime;  // Obsolete: use DateTimeOffset instead!!
             if (typeof(Decimal) == to)
-                return XmlConvert.ToDecimal(value);
+            {
+                if (Array.Exists(new[] { "+", ".", "00" }, c => value.StartsWith(c)) || value.EndsWith("."))
+                {
+                    // decimal cannot start with '+', '-' or '00' and cannot end with '-'
+                    throw new FormatException("Input string was not in a correct format.");
+                }
+                return decimal.Parse(value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+            }
             if (typeof(Double) == to)
                 return XmlConvert.ToDouble(value);      // Could lead to loss in precision
             if (typeof(Int16) == to)


### PR DESCRIPTION
Allow now also Exponents in de primitive type decimal, which actually only allowed from R4

So 1.2e2 is now also correct decimal.